### PR TITLE
first CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# Trigger the workflow on push or pull request, but only for the main branch
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+defaults:
+  run:
+    working-directory: ./botan-bindings # FIXME figure out a good setup for the various botan sub-projects
+
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    runs-on: ubuntu-latest        
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        run: |
+          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
+          chmod +x get-tested
+          ./get-tested --ubuntu --macos get-tested.cabal >> $GITHUB_OUTPUT
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get -y install botan
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+      - name: Configure
+        run: cabal new-configure --enable-tests
+      - name: Freeze
+        run: cabal freeze
+      - name: Cache
+        uses: actions/cache@v3.3.2
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+      - name: Build
+        run: cabal new-build
+      - name: Test
+        run: cabal new-test all


### PR DESCRIPTION
Hi, I've added a Github Actions workflow file using `get-tested` (https://github.com/Kleidukos/get-tested/) to generate the build matrix from the "tested-with" Cabal stanza. Which currently `botan-bindings` doesn't have :D 

So, it's just a matter of adding "tested-with" and we can reap the benefits of build and test automation, hopefully :)