### PR TITLE
Improve cipherUpdate

### DIFF
--- a/botan-bindings/src/Botan/Bindings/Cipher.hs
+++ b/botan-bindings/src/Botan/Bindings/Cipher.hs
@@ -180,7 +180,7 @@ Encrypt some data
                                   size_t input_size,
                                   size_t* input_consumed);@
 -}
-foreign import ccall unsafe botan_cipher_update
+foreign import ccall safe botan_cipher_update
     :: CipherPtr
     -> CipherUpdateFlags
     -> Ptr Word8    -- output

--- a/botan-low/src/Botan/Low/Cipher.hs
+++ b/botan-low/src/Botan/Low/Cipher.hs
@@ -131,7 +131,7 @@ cipherStart = mkSetBytesLen withCipherPtr botan_cipher_start
 -- Some ciphers (ChaChaPoly, EAX) may consume less input than the reported ideal granularity
 cipherUpdate :: CipherCtx -> CipherUpdateFlags -> Int -> ByteString -> IO (Int,ByteString)
 cipherUpdate ctx flags outputSz input = withCipherPtr ctx $ \ ctxPtr -> do
-    asBytesLen input $ \ inputPtr inputSz -> do
+    unsafeAsBytesLen input $ \ inputPtr inputSz -> do
         alloca $ \ consumedPtr -> do
             alloca $ \ writtenPtr -> do
                 output <- allocBytes outputSz $ \ outputPtr -> do


### PR DESCRIPTION
1) Don't use unsafe import for functions which pass control to C for unbounded amount of time since then a Haskell thread that runs them can't be preempted. In fact, it might be best to import everything as safe and change some functions to unsafe later as an optimization pass (if it's even needed).

2) Don't make a copy of the input text - when performing operations on large ByteStringS, duplicating the memory used by them is not desirable. This also applies to other relevant functions that use asBytesLen where unsafeAsBytesLen is sufficient. ByteStringS are pinned, so doing this is fine.