### PR TITLE
`botan`: enable GHC warnings, use `GHC2021`, add export lists

### DIFF
--- a/botan/botan.cabal
+++ b/botan/botan.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            botan
-version:         0.0.1.0
+version:         0.1.0.0
 synopsis:        High-level Botan bindings
 description:
   Welcome to botan
@@ -49,32 +49,31 @@ source-repository this
   type:     git
   location: https://github.com/haskellfoundation/botan
   subdir:   botan
-  tag:      botan-0.0.1.0
+  tag:      botan-0.1.0.0
+
+common warnings
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists
+    -Wno-unticked-promoted-constructors -Wunused-packages
+    -Wmissing-deriving-strategies
+
+common language
+  default-language:   GHC2021
+  default-extensions:
+    DerivingStrategies
+    PatternSynonyms
+    RecordWildCards
+    RoleAnnotations
 
 library
+  import:             warnings, language
   hs-source-dirs:     src
-  default-language:   Haskell2010
   default-extensions:
-    ConstraintKinds
-    DataKinds
-    DefaultSignatures
-    DerivingStrategies
-    FlexibleContexts
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    InstanceSigs
-    MultiParamTypeClasses
     NoImplicitPrelude
     OverloadedStrings
-    PatternSynonyms
-    ScopedTypeVariables
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeOperators
 
-  -- NOTE: Botan does not directly expose padding
-  -- Botan.Padding
   exposed-modules:
     Botan.Bcrypt
     Botan.BlockCipher
@@ -88,6 +87,7 @@ library
     Botan.BlockCipher.GOST
     Botan.BlockCipher.IDEA
     Botan.BlockCipher.Noekeon
+    Botan.BlockCipher.SEED
     Botan.BlockCipher.Serpent
     Botan.BlockCipher.SHALCAL
     Botan.BlockCipher.SM4
@@ -125,6 +125,7 @@ library
     Botan.MAC.CMAC
     Botan.OneTimeAuth.Class
     Botan.OneTimeAuth.Poly1305
+    Botan.Padding
     Botan.PubKey
     Botan.PubKey.Decrypt
     Botan.PubKey.Encrypt
@@ -148,12 +149,11 @@ library
 
   autogen-modules:    Paths_botan
   build-depends:
-    , base            >=4.16 && <4.22
-    , botan-bindings  ^>=0.0 || ^>=0.1
-    , botan-low       ^>=0.0
-    , bytestring      >=0.11 && <0.13
-    , deepseq         >=1.1  && <2
-    , text            >=1.2  && <1.3   || >=2.0 && <2.2
+    , base        >=4.16 && <4.22
+    , botan-low   ^>=0.0
+    , bytestring  >=0.11 && <0.13
+    , deepseq     >=1.1  && <2
+    , text        >=1.2  && <1.3  || >=2.0 && <2.2
 
   if flag(mtl)
     build-depends: mtl >=2.2 && <2.4

--- a/botan/src/Botan/Bcrypt.hs
+++ b/botan/src/Botan/Bcrypt.hs
@@ -11,39 +11,34 @@ Portability : POSIX
 Generate and validate Bcrypt password hashes
 -}
 
-module Botan.Bcrypt
-(
+module Botan.Bcrypt (
 
--- * Bcrypt
--- $introduction
+  -- * Bcrypt
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Work factors
-  WorkFactor(..)
-, workFactor
-, toWorkFactor
+  -- * Work factors
+    WorkFactor(..)
+  , workFactor
+  , toWorkFactor
 
--- * Generating a bcrypt digest
-, Password(..)
-, BcryptDigest(..)
-, bcryptGenerate
-, bcryptGenerateRNG
-, unsafeBcryptGenerateRNG
+  -- * Generating a bcrypt digest
+  , Password
+  , BcryptDigest
+  , bcryptGenerate
+  , bcryptGenerateRNG
+  , unsafeBcryptGenerateRNG
 
--- * Validating a bcrypt digest
-, bcryptValidate
-, unsafeBcryptValidate
+  -- * Validating a bcrypt digest
+  , bcryptValidate
+  , unsafeBcryptValidate
 
-) where
-
-import qualified Data.ByteString as ByteString
+  ) where
 
 import qualified Botan.Low.Bcrypt as Low
-import qualified Botan.Low.RNG as Low
 
-import           Botan.Error
 import           Botan.Prelude
 import           Botan.RNG
 
@@ -88,7 +83,7 @@ data WorkFactor
     | Good
     | Strong
     | WorkFactor Low.BcryptWorkFactor
-    deriving (Show)
+    deriving stock (Show)
 
 instance Eq WorkFactor where
     a == b = (workFactor a == workFactor b)
@@ -144,15 +139,6 @@ bcryptGenerateRNG
     -> WorkFactor   -- ^ A work factor to slow down guessing attack
     -> m BcryptDigest
 bcryptGenerateRNG rng pass wf = liftIO $ Low.bcryptGenerate pass rng (workFactor wf)
-
--- |This function is unsafe as it may block for an indeterminate
---  amount of time
-unsafeBcryptGenerateSystem
-    :: Password         -- ^ The password to check against
-    -> WorkFactor       -- ^ A work factor to slow down guessing attack
-    -> BcryptDigest
-unsafeBcryptGenerateSystem = unsafePerformIO3 bcryptGenerateRNG systemRNG
-{-# NOINLINE unsafeBcryptGenerateSystem #-}
 
 {- |
 This function is unsafe as it may block for an indeterminate amount of time

--- a/botan/src/Botan/BlockCipher.hs
+++ b/botan/src/Botan/BlockCipher.hs
@@ -13,108 +13,107 @@ Most applications want the higher level cipher API which provides authenticated 
 This API exists as an escape hatch for applications which need to implement custom primitives using a PRP.
 -}
 
-module Botan.BlockCipher -- where
-(
+module Botan.BlockCipher (
 
--- * Block ciphers
--- $introduction
+  -- * Block ciphers
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Idiomatic interface
+  -- * Idiomatic interface
 
--- ** Data type
-  BlockCipher(..)
-, BlockCipher128(..)
+  -- ** Data type
+    BlockCipher(..)
+  , BlockCipher128(..)
 
--- ** Enumerations
+  -- ** Enumerations
 
-, blockCiphers
-, blockCipher128s
+  , blockCiphers
+  , blockCipher128s
 
--- ** Associated types
-, BlockCipherKeySpec(..)
-, BlockCipherKey(..)
-, newBlockCipherKey
-, newBlockCipherKeyMaybe
-, BlockCipherText(..)
+  -- ** Associated types
+  , BlockCipherKeySpec
+  , BlockCipherKey
+  , newBlockCipherKey
+  , newBlockCipherKeyMaybe
+  , BlockCipherText
 
--- ** Convenience
-, BlockCipher128Key(..)
-, blockCipher128Name
-, blockCipher128KeySpec
-, isBlockCipher128
+  -- ** Convenience
+  , BlockCipher128Key
+  , blockCipher128Name
+  , blockCipher128KeySpec
+  , isBlockCipher128
 
--- ** Accessors
+  -- ** Accessors
 
-, blockCipherName
-, blockCipherBlockSize
-, blockCipherKeySpec
+  , blockCipherName
+  , blockCipherBlockSize
+  , blockCipherKeySpec
 
--- ** Idiomatic algorithm
-, blockCipherEncrypt
-, blockCipherDecrypt
-, blockCipherEncryptLazy
-, blockCipherDecryptLazy
+  -- ** Idiomatic algorithm
+  , blockCipherEncrypt
+  , blockCipherDecrypt
+  , blockCipherEncryptLazy
+  , blockCipherDecryptLazy
 
--- * Mutable interface
+  -- * Mutable interface
 
--- ** Tagged mutable context
-, MutableBlockCipher(..)
+  -- ** Tagged mutable context
+  , MutableBlockCipher(..)
 
--- ** Destructor
-, destroyBlockCipher
+  -- ** Destructor
+  , destroyBlockCipher
 
--- ** Initializers
-, newBlockCipher
--- , newBlockCipher128
+  -- ** Initializers
+  , newBlockCipher
+  -- , newBlockCipher128
 
--- ** Accessors
-, getBlockCipherName
-, getBlockCipherBlockSize
-, getBlockCipherKeySpec
-, setBlockCipherKey
+  -- ** Accessors
+  , getBlockCipherName
+  , getBlockCipherBlockSize
+  , getBlockCipherKeySpec
+  , setBlockCipherKey
 
--- ** Accessory functions
-, clearBlockCipher
+  -- ** Accessory functions
+  , clearBlockCipher
 
--- ** Mutable algorithm
-, encryptBlockCipherBlocks
-, decryptBlockCipherBlocks
-, autoEncryptBlockCipherBlocks
--- , autoEncryptBlockCipherBlocksGeneratingkey
-, autoDecryptBlockCipherBlocks
+  -- ** Mutable algorithm
+  , encryptBlockCipherBlocks
+  , decryptBlockCipherBlocks
+  , autoEncryptBlockCipherBlocks
+  -- , autoEncryptBlockCipherBlocksGeneratingkey
+  , autoDecryptBlockCipherBlocks
 
--- Algorithm references
+  -- Algorithm references
 
-, blowfish
-, cast128
-, des
-, tripleDES
-, gost_28147_89
-, idea
+  , blowfish
+  , cast128
+  , des
+  , tripleDES
+  , gost_28147_89
+  , idea
 
-, aes128
-, aes192
-, aes256
-, aria128
-, aria192
-, aria256
-, camellia128
-, camellia192
-, camellia256
-, noekeon
-, seed
-, sm4
-, serpent
-, twofish
+  , aes128
+  , aes192
+  , aes256
+  , aria128
+  , aria192
+  , aria256
+  , camellia128
+  , camellia192
+  , camellia256
+  , noekeon
+  , seed
+  , sm4
+  , serpent
+  , twofish
 
-, shalcal2
+  , shalcal2
 
-, threefish512
+  , threefish512
 
-) where
+  ) where
 
 import qualified Botan.Low.BlockCipher as Low
 
@@ -170,7 +169,7 @@ data BlockCipher
     | Threefish512
     -- | Cascade BlockCipher BlockCipher
     -- | Lion HashSpec StreamCipher Int
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 -- NOTE: An enumeration of all block ciphers, assuming default values if any parameters exist
 -- TODO: Maybe rename supportedBlockCiphers? Repeat pattern elsewhere?
@@ -203,7 +202,7 @@ blockCiphers =
 -- 128-bit block cipher type
 
 newtype BlockCipher128 = MkBlockCipher128 { unBlockCipher128 :: BlockCipher }
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 blockCipher128 :: BlockCipher -> Maybe BlockCipher128
 blockCipher128 bc@AES128      = Just $ MkBlockCipher128 bc
@@ -221,9 +220,6 @@ blockCipher128 bc@Serpent     = Just $ MkBlockCipher128 bc
 blockCipher128 bc@SM4         = Just $ MkBlockCipher128 bc
 blockCipher128 bc@Twofish     = Just $ MkBlockCipher128 bc
 blockCipher128 _              = Nothing
-
-unsafeBlockCipher128 :: BlockCipher -> BlockCipher128
-unsafeBlockCipher128 = MkBlockCipher128
 
 blockCipher128s :: [ BlockCipher128 ]
 blockCipher128s = fmap MkBlockCipher128

--- a/botan/src/Botan/BlockCipher/AES.hs
+++ b/botan/src/Botan/BlockCipher/AES.hs
@@ -1,39 +1,38 @@
-module Botan.BlockCipher.AES
-( AES128(..)
-, AES128SecretKey(..)
-, pattern AES128SecretKey
-, getAES128SecretKey
-, AES128Ciphertext(..)
-, aes128Encrypt
-, aes128Decrypt
-, aes128EncryptLazy
-, aes128DecryptLazy
-, AES192(..)
-, AES192SecretKey(..)
-, pattern AES192SecretKey
-, getAES192SecretKey
-, AES192Ciphertext(..)
-, aes192Encrypt
-, aes192Decrypt
-, aes192EncryptLazy
-, aes192DecryptLazy
-, AES256(..)
-, AES256SecretKey(..)
-, pattern AES256SecretKey
-, getAES256SecretKey
-, AES256Ciphertext(..)
-, aes256Encrypt
-, aes256Decrypt
-, aes256EncryptLazy
-, aes256DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.AES (
+    AES128
+  , AES128SecretKey
+  , pattern AES128SecretKey
+  , getAES128SecretKey
+  , AES128Ciphertext
+  , aes128Encrypt
+  , aes128Decrypt
+  , aes128EncryptLazy
+  , aes128DecryptLazy
+  , AES192
+  , AES192SecretKey
+  , pattern AES192SecretKey
+  , getAES192SecretKey
+  , AES192Ciphertext
+  , aes192Encrypt
+  , aes192Decrypt
+  , aes192EncryptLazy
+  , aes192DecryptLazy
+  , AES256
+  , AES256SecretKey
+  , pattern AES256SecretKey
+  , getAES256SecretKey
+  , AES256Ciphertext
+  , aes256Encrypt
+  , aes256Decrypt
+  , aes256EncryptLazy
+  , aes256DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -48,6 +47,7 @@ data AES128
 newtype instance SecretKey AES128 = MkAES128SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES128SecretKey #-}
 pattern AES128SecretKey :: ByteString -> SecretKey AES128
 pattern AES128SecretKey bytes = MkAES128SecretKey (MkGSecretKey bytes)
 
@@ -59,22 +59,17 @@ type AES128SecretKey = SecretKey AES128
 newtype instance Ciphertext AES128 = MkAES128Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES128Ciphertext #-}
 pattern AES128Ciphertext :: ByteString -> Ciphertext AES128
 pattern AES128Ciphertext bs = MkAES128Ciphertext (MkGCiphertext bs)
-
-getAES128Ciphertext :: Ciphertext AES128 -> ByteString
-getAES128Ciphertext (AES128Ciphertext bs) = bs
-
 type AES128Ciphertext = Ciphertext AES128
 
 newtype instance LazyCiphertext AES128 = MkAES128LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE AES128LazyCiphertext #-}
 pattern AES128LazyCiphertext :: Lazy.ByteString -> LazyCiphertext AES128
 pattern AES128LazyCiphertext lbs = MkAES128LazyCiphertext (MkGLazyCiphertext lbs)
-
-getAES128LazyCiphertext :: LazyCiphertext AES128 -> Lazy.ByteString
-getAES128LazyCiphertext (AES128LazyCiphertext bs) = bs
 
 type AES128LazyCiphertext = LazyCiphertext AES128
 
@@ -83,12 +78,12 @@ instance HasSecretKey AES128 where
     secretKeySpec :: SizeSpecifier (SecretKey AES128)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aes128
 
-instance (MonadRandomIO m )=> SecretKeyGen AES128 m where
+instance MonadRandomIO m => SecretKeyGen AES128 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey AES128)
+    newSecretKey :: m (SecretKey AES128)
     newSecretKey = AES128SecretKey <$> newSized (secretKeySpec @AES128)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey AES128))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey AES128))
     newSecretKeyMaybe i = fmap AES128SecretKey <$> newSizedMaybe (secretKeySpec @AES128) i
 
 instance HasCiphertext AES128 where
@@ -132,6 +127,7 @@ data AES192
 newtype instance SecretKey AES192 = MkAES192SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES192SecretKey #-}
 pattern AES192SecretKey :: ByteString -> SecretKey AES192
 pattern AES192SecretKey bytes = MkAES192SecretKey (MkGSecretKey bytes)
 
@@ -143,22 +139,18 @@ type AES192SecretKey = SecretKey AES192
 newtype instance Ciphertext AES192 = MkAES192Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES192Ciphertext #-}
 pattern AES192Ciphertext :: ByteString -> Ciphertext AES192
 pattern AES192Ciphertext bs = MkAES192Ciphertext (MkGCiphertext bs)
-
-getAES192Ciphertext :: Ciphertext AES192 -> ByteString
-getAES192Ciphertext (AES192Ciphertext bs) = bs
 
 type AES192Ciphertext = Ciphertext AES192
 
 newtype instance LazyCiphertext AES192 = MkAES192LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE AES192LazyCiphertext #-}
 pattern AES192LazyCiphertext :: Lazy.ByteString -> LazyCiphertext AES192
 pattern AES192LazyCiphertext lbs = MkAES192LazyCiphertext (MkGLazyCiphertext lbs)
-
-getAES192LazyCiphertext :: LazyCiphertext AES192 -> Lazy.ByteString
-getAES192LazyCiphertext (AES192LazyCiphertext bs) = bs
 
 type AES192LazyCiphertext = LazyCiphertext AES192
 
@@ -167,12 +159,12 @@ instance HasSecretKey AES192 where
     secretKeySpec :: SizeSpecifier (SecretKey AES192)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aes192
 
-instance (MonadRandomIO m )=> SecretKeyGen AES192 m where
+instance MonadRandomIO m => SecretKeyGen AES192 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey AES192)
+    newSecretKey :: m (SecretKey AES192)
     newSecretKey = AES192SecretKey <$> newSized (secretKeySpec @AES192)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey AES192))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey AES192))
     newSecretKeyMaybe i = fmap AES192SecretKey <$> newSizedMaybe (secretKeySpec @AES192) i
 
 instance HasCiphertext AES192 where
@@ -216,6 +208,7 @@ data AES256
 newtype instance SecretKey AES256 = MkAES256SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES256SecretKey #-}
 pattern AES256SecretKey :: ByteString -> SecretKey AES256
 pattern AES256SecretKey bytes = MkAES256SecretKey (MkGSecretKey bytes)
 
@@ -227,22 +220,18 @@ type AES256SecretKey = SecretKey AES256
 newtype instance Ciphertext AES256 = MkAES256Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE AES256Ciphertext #-}
 pattern AES256Ciphertext :: ByteString -> Ciphertext AES256
 pattern AES256Ciphertext bs = MkAES256Ciphertext (MkGCiphertext bs)
-
-getAES256Ciphertext :: Ciphertext AES256 -> ByteString
-getAES256Ciphertext (AES256Ciphertext bs) = bs
 
 type AES256Ciphertext = Ciphertext AES256
 
 newtype instance LazyCiphertext AES256 = MkAES256LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE AES256LazyCiphertext #-}
 pattern AES256LazyCiphertext :: Lazy.ByteString -> LazyCiphertext AES256
 pattern AES256LazyCiphertext lbs = MkAES256LazyCiphertext (MkGLazyCiphertext lbs)
-
-getAES256LazyCiphertext :: LazyCiphertext AES256 -> Lazy.ByteString
-getAES256LazyCiphertext (AES256LazyCiphertext bs) = bs
 
 type AES256LazyCiphertext = LazyCiphertext AES256
 
@@ -251,12 +240,12 @@ instance HasSecretKey AES256 where
     secretKeySpec :: SizeSpecifier (SecretKey AES256)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aes256
 
-instance (MonadRandomIO m )=> SecretKeyGen AES256 m where
+instance MonadRandomIO m => SecretKeyGen AES256 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey AES256)
+    newSecretKey :: m (SecretKey AES256)
     newSecretKey = AES256SecretKey <$> newSized (secretKeySpec @AES256)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey AES256))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey AES256))
     newSecretKeyMaybe i = fmap AES256SecretKey <$> newSizedMaybe (secretKeySpec @AES256) i
 
 instance HasCiphertext AES256 where

--- a/botan/src/Botan/BlockCipher/ARIA.hs
+++ b/botan/src/Botan/BlockCipher/ARIA.hs
@@ -1,39 +1,38 @@
-module Botan.BlockCipher.ARIA
-( ARIA128(..)
-, ARIA128SecretKey(..)
-, pattern ARIA128SecretKey
-, getARIA128SecretKey
-, ARIA128Ciphertext(..)
-, aria128Encrypt
-, aria128Decrypt
-, aria128EncryptLazy
-, aria128DecryptLazy
-, ARIA192(..)
-, ARIA192SecretKey(..)
-, pattern ARIA192SecretKey
-, getARIA192SecretKey
-, ARIA192Ciphertext(..)
-, aria192Encrypt
-, aria192Decrypt
-, aria192EncryptLazy
-, aria192DecryptLazy
-, ARIA256(..)
-, ARIA256SecretKey(..)
-, pattern ARIA256SecretKey
-, getARIA256SecretKey
-, ARIA256Ciphertext(..)
-, aria256Encrypt
-, aria256Decrypt
-, aria256EncryptLazy
-, aria256DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.ARIA (
+    ARIA128
+  , ARIA128SecretKey
+  , pattern ARIA128SecretKey
+  , getARIA128SecretKey
+  , ARIA128Ciphertext
+  , aria128Encrypt
+  , aria128Decrypt
+  , aria128EncryptLazy
+  , aria128DecryptLazy
+  , ARIA192
+  , ARIA192SecretKey
+  , pattern ARIA192SecretKey
+  , getARIA192SecretKey
+  , ARIA192Ciphertext
+  , aria192Encrypt
+  , aria192Decrypt
+  , aria192EncryptLazy
+  , aria192DecryptLazy
+  , ARIA256
+  , ARIA256SecretKey
+  , pattern ARIA256SecretKey
+  , getARIA256SecretKey
+  , ARIA256Ciphertext
+  , aria256Encrypt
+  , aria256Decrypt
+  , aria256EncryptLazy
+  , aria256DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -48,6 +47,7 @@ data ARIA128
 newtype instance SecretKey ARIA128 = MkARIA128SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA128SecretKey #-}
 pattern ARIA128SecretKey :: ByteString -> SecretKey ARIA128
 pattern ARIA128SecretKey bytes = MkARIA128SecretKey (MkGSecretKey bytes)
 
@@ -59,22 +59,18 @@ type ARIA128SecretKey = SecretKey ARIA128
 newtype instance Ciphertext ARIA128 = MkARIA128Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA128Ciphertext #-}
 pattern ARIA128Ciphertext :: ByteString -> Ciphertext ARIA128
 pattern ARIA128Ciphertext bs = MkARIA128Ciphertext (MkGCiphertext bs)
-
-getARIA128Ciphertext :: Ciphertext ARIA128 -> ByteString
-getARIA128Ciphertext (ARIA128Ciphertext bs) = bs
 
 type ARIA128Ciphertext = Ciphertext ARIA128
 
 newtype instance LazyCiphertext ARIA128 = MkARIA128LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE ARIA128LazyCiphertext #-}
 pattern ARIA128LazyCiphertext :: Lazy.ByteString -> LazyCiphertext ARIA128
 pattern ARIA128LazyCiphertext lbs = MkARIA128LazyCiphertext (MkGLazyCiphertext lbs)
-
-getARIA128LazyCiphertext :: LazyCiphertext ARIA128 -> Lazy.ByteString
-getARIA128LazyCiphertext (ARIA128LazyCiphertext bs) = bs
 
 type ARIA128LazyCiphertext = LazyCiphertext ARIA128
 
@@ -83,12 +79,12 @@ instance HasSecretKey ARIA128 where
     secretKeySpec :: SizeSpecifier (SecretKey ARIA128)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aria128
 
-instance (MonadRandomIO m )=> SecretKeyGen ARIA128 m where
+instance MonadRandomIO m => SecretKeyGen ARIA128 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey ARIA128)
+    newSecretKey :: m (SecretKey ARIA128)
     newSecretKey = ARIA128SecretKey <$> newSized (secretKeySpec @ARIA128)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey ARIA128))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey ARIA128))
     newSecretKeyMaybe i = fmap ARIA128SecretKey <$> newSizedMaybe (secretKeySpec @ARIA128) i
 
 instance HasCiphertext ARIA128 where
@@ -132,6 +128,7 @@ data ARIA192
 newtype instance SecretKey ARIA192 = MkARIA192SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA192SecretKey #-}
 pattern ARIA192SecretKey :: ByteString -> SecretKey ARIA192
 pattern ARIA192SecretKey bytes = MkARIA192SecretKey (MkGSecretKey bytes)
 
@@ -143,22 +140,18 @@ type ARIA192SecretKey = SecretKey ARIA192
 newtype instance Ciphertext ARIA192 = MkARIA192Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA192Ciphertext #-}
 pattern ARIA192Ciphertext :: ByteString -> Ciphertext ARIA192
 pattern ARIA192Ciphertext bs = MkARIA192Ciphertext (MkGCiphertext bs)
 
-getARIA192Ciphertext :: Ciphertext ARIA192 -> ByteString
-getARIA192Ciphertext (ARIA192Ciphertext bs) = bs
-
 type ARIA192Ciphertext = Ciphertext ARIA192
 
+{-# COMPLETE ARIA192LazyCiphertext #-}
 newtype instance LazyCiphertext ARIA192 = MkARIA192LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
 pattern ARIA192LazyCiphertext :: Lazy.ByteString -> LazyCiphertext ARIA192
 pattern ARIA192LazyCiphertext lbs = MkARIA192LazyCiphertext (MkGLazyCiphertext lbs)
-
-getARIA192LazyCiphertext :: LazyCiphertext ARIA192 -> Lazy.ByteString
-getARIA192LazyCiphertext (ARIA192LazyCiphertext bs) = bs
 
 type ARIA192LazyCiphertext = LazyCiphertext ARIA192
 
@@ -167,12 +160,12 @@ instance HasSecretKey ARIA192 where
     secretKeySpec :: SizeSpecifier (SecretKey ARIA192)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aria192
 
-instance (MonadRandomIO m )=> SecretKeyGen ARIA192 m where
+instance MonadRandomIO m => SecretKeyGen ARIA192 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey ARIA192)
+    newSecretKey :: m (SecretKey ARIA192)
     newSecretKey = ARIA192SecretKey <$> newSized (secretKeySpec @ARIA192)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey ARIA192))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey ARIA192))
     newSecretKeyMaybe i = fmap ARIA192SecretKey <$> newSizedMaybe (secretKeySpec @ARIA192) i
 
 instance HasCiphertext ARIA192 where
@@ -216,6 +209,7 @@ data ARIA256
 newtype instance SecretKey ARIA256 = MkARIA256SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA256SecretKey #-}
 pattern ARIA256SecretKey :: ByteString -> SecretKey ARIA256
 pattern ARIA256SecretKey bytes = MkARIA256SecretKey (MkGSecretKey bytes)
 
@@ -227,22 +221,18 @@ type ARIA256SecretKey = SecretKey ARIA256
 newtype instance Ciphertext ARIA256 = MkARIA256Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ARIA256Ciphertext #-}
 pattern ARIA256Ciphertext :: ByteString -> Ciphertext ARIA256
 pattern ARIA256Ciphertext bs = MkARIA256Ciphertext (MkGCiphertext bs)
-
-getARIA256Ciphertext :: Ciphertext ARIA256 -> ByteString
-getARIA256Ciphertext (ARIA256Ciphertext bs) = bs
 
 type ARIA256Ciphertext = Ciphertext ARIA256
 
 newtype instance LazyCiphertext ARIA256 = MkARIA256LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE ARIA256LazyCiphertext #-}
 pattern ARIA256LazyCiphertext :: Lazy.ByteString -> LazyCiphertext ARIA256
 pattern ARIA256LazyCiphertext lbs = MkARIA256LazyCiphertext (MkGLazyCiphertext lbs)
-
-getARIA256LazyCiphertext :: LazyCiphertext ARIA256 -> Lazy.ByteString
-getARIA256LazyCiphertext (ARIA256LazyCiphertext bs) = bs
 
 type ARIA256LazyCiphertext = LazyCiphertext ARIA256
 
@@ -251,12 +241,12 @@ instance HasSecretKey ARIA256 where
     secretKeySpec :: SizeSpecifier (SecretKey ARIA256)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.aria256
 
-instance (MonadRandomIO m )=> SecretKeyGen ARIA256 m where
+instance MonadRandomIO m => SecretKeyGen ARIA256 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey ARIA256)
+    newSecretKey :: m (SecretKey ARIA256)
     newSecretKey = ARIA256SecretKey <$> newSized (secretKeySpec @ARIA256)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey ARIA256))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey ARIA256))
     newSecretKeyMaybe i = fmap ARIA256SecretKey <$> newSizedMaybe (secretKeySpec @ARIA256) i
 
 instance HasCiphertext ARIA256 where

--- a/botan/src/Botan/BlockCipher/Blowfish.hs
+++ b/botan/src/Botan/BlockCipher/Blowfish.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.Blowfish
-( Blowfish(..)
-, BlowfishSecretKey(..)
-, pattern BlowfishSecretKey
-, getBlowfishSecretKey
-, BlowfishCiphertext(..)
-, blowfishEncrypt
-, blowfishDecrypt
-, blowfishEncryptLazy
-, blowfishDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Blowfish (
+    Blowfish
+  , BlowfishSecretKey
+  , pattern BlowfishSecretKey
+  , getBlowfishSecretKey
+  , BlowfishCiphertext
+  , blowfishEncrypt
+  , blowfishDecrypt
+  , blowfishEncryptLazy
+  , blowfishDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data Blowfish
 newtype instance SecretKey Blowfish = MkBlowfishSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE BlowfishSecretKey #-}
 pattern BlowfishSecretKey :: ByteString -> SecretKey Blowfish
 pattern BlowfishSecretKey bytes = MkBlowfishSecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type BlowfishSecretKey = SecretKey Blowfish
 newtype instance Ciphertext Blowfish = MkBlowfishCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE BlowfishCiphertext #-}
 pattern BlowfishCiphertext :: ByteString -> Ciphertext Blowfish
 pattern BlowfishCiphertext bs = MkBlowfishCiphertext (MkGCiphertext bs)
-
-getBlowfishCiphertext :: Ciphertext Blowfish -> ByteString
-getBlowfishCiphertext (BlowfishCiphertext bs) = bs
 
 type BlowfishCiphertext = Ciphertext Blowfish
 
 newtype instance LazyCiphertext Blowfish = MkBlowfishLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE BlowfishLazyCiphertext #-}
 pattern BlowfishLazyCiphertext :: Lazy.ByteString -> LazyCiphertext Blowfish
 pattern BlowfishLazyCiphertext lbs = MkBlowfishLazyCiphertext (MkGLazyCiphertext lbs)
-
-getBlowfishLazyCiphertext :: LazyCiphertext Blowfish -> Lazy.ByteString
-getBlowfishLazyCiphertext (BlowfishLazyCiphertext bs) = bs
 
 type BlowfishLazyCiphertext = LazyCiphertext Blowfish
 
@@ -65,12 +61,12 @@ instance HasSecretKey Blowfish where
     secretKeySpec :: SizeSpecifier (SecretKey Blowfish)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.blowfish
 
-instance (MonadRandomIO m )=> SecretKeyGen Blowfish m where
+instance MonadRandomIO m => SecretKeyGen Blowfish m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Blowfish)
+    newSecretKey :: m (SecretKey Blowfish)
     newSecretKey = BlowfishSecretKey <$> newSized (secretKeySpec @Blowfish)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Blowfish))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Blowfish))
     newSecretKeyMaybe i = fmap BlowfishSecretKey <$> newSizedMaybe (secretKeySpec @Blowfish) i
 
 instance HasCiphertext Blowfish where

--- a/botan/src/Botan/BlockCipher/CAST.hs
+++ b/botan/src/Botan/BlockCipher/CAST.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.CAST
-( CAST128(..)
-, CAST128SecretKey(..)
-, pattern CAST128SecretKey
-, getCAST128SecretKey
-, CAST128Ciphertext(..)
-, cast128Encrypt
-, cast128Decrypt
-, cast128EncryptLazy
-, cast128DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.CAST (
+    CAST128
+  , CAST128SecretKey
+  , pattern CAST128SecretKey
+  , getCAST128SecretKey
+  , CAST128Ciphertext
+  , cast128Encrypt
+  , cast128Decrypt
+  , cast128EncryptLazy
+  , cast128DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data CAST128
 newtype instance SecretKey CAST128 = MkCAST128SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE CAST128SecretKey #-}
 pattern CAST128SecretKey :: ByteString -> SecretKey CAST128
 pattern CAST128SecretKey bytes = MkCAST128SecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type CAST128SecretKey = SecretKey CAST128
 newtype instance Ciphertext CAST128 = MkCAST128Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE CAST128Ciphertext #-}
 pattern CAST128Ciphertext :: ByteString -> Ciphertext CAST128
 pattern CAST128Ciphertext bs = MkCAST128Ciphertext (MkGCiphertext bs)
-
-getCAST128Ciphertext :: Ciphertext CAST128 -> ByteString
-getCAST128Ciphertext (CAST128Ciphertext bs) = bs
 
 type CAST128Ciphertext = Ciphertext CAST128
 
 newtype instance LazyCiphertext CAST128 = MkCAST128LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE CAST128LazyCiphertext #-}
 pattern CAST128LazyCiphertext :: Lazy.ByteString -> LazyCiphertext CAST128
 pattern CAST128LazyCiphertext lbs = MkCAST128LazyCiphertext (MkGLazyCiphertext lbs)
-
-getCAST128LazyCiphertext :: LazyCiphertext CAST128 -> Lazy.ByteString
-getCAST128LazyCiphertext (CAST128LazyCiphertext bs) = bs
 
 type CAST128LazyCiphertext = LazyCiphertext CAST128
 
@@ -65,12 +61,12 @@ instance HasSecretKey CAST128 where
     secretKeySpec :: SizeSpecifier (SecretKey CAST128)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.cast128
 
-instance (MonadRandomIO m )=> SecretKeyGen CAST128 m where
+instance MonadRandomIO m => SecretKeyGen CAST128 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey CAST128)
+    newSecretKey :: m (SecretKey CAST128)
     newSecretKey = CAST128SecretKey <$> newSized (secretKeySpec @CAST128)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey CAST128))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey CAST128))
     newSecretKeyMaybe i = fmap CAST128SecretKey <$> newSizedMaybe (secretKeySpec @CAST128) i
 
 instance HasCiphertext CAST128 where

--- a/botan/src/Botan/BlockCipher/Camellia.hs
+++ b/botan/src/Botan/BlockCipher/Camellia.hs
@@ -1,39 +1,38 @@
-module Botan.BlockCipher.Camellia
-( Camellia128(..)
-, Camellia128SecretKey(..)
-, pattern Camellia128SecretKey
-, getCamellia128SecretKey
-, Camellia128Ciphertext(..)
-, camellia128Encrypt
-, camellia128Decrypt
-, camellia128EncryptLazy
-, camellia128DecryptLazy
-, Camellia192(..)
-, Camellia192SecretKey(..)
-, pattern Camellia192SecretKey
-, getCamellia192SecretKey
-, Camellia192Ciphertext(..)
-, camellia192Encrypt
-, camellia192Decrypt
-, camellia192EncryptLazy
-, camellia192DecryptLazy
-, Camellia256(..)
-, Camellia256SecretKey(..)
-, pattern Camellia256SecretKey
-, getCamellia256SecretKey
-, Camellia256Ciphertext(..)
-, camellia256Encrypt
-, camellia256Decrypt
-, camellia256EncryptLazy
-, camellia256DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Camellia (
+    Camellia128
+  , Camellia128SecretKey
+  , pattern Camellia128SecretKey
+  , getCamellia128SecretKey
+  , Camellia128Ciphertext
+  , camellia128Encrypt
+  , camellia128Decrypt
+  , camellia128EncryptLazy
+  , camellia128DecryptLazy
+  , Camellia192
+  , Camellia192SecretKey
+  , pattern Camellia192SecretKey
+  , getCamellia192SecretKey
+  , Camellia192Ciphertext
+  , camellia192Encrypt
+  , camellia192Decrypt
+  , camellia192EncryptLazy
+  , camellia192DecryptLazy
+  , Camellia256
+  , Camellia256SecretKey
+  , pattern Camellia256SecretKey
+  , getCamellia256SecretKey
+  , Camellia256Ciphertext
+  , camellia256Encrypt
+  , camellia256Decrypt
+  , camellia256EncryptLazy
+  , camellia256DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -48,6 +47,7 @@ data Camellia128
 newtype instance SecretKey Camellia128 = MkCamellia128SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia128SecretKey #-}
 pattern Camellia128SecretKey :: ByteString -> SecretKey Camellia128
 pattern Camellia128SecretKey bytes = MkCamellia128SecretKey (MkGSecretKey bytes)
 
@@ -59,22 +59,18 @@ type Camellia128SecretKey = SecretKey Camellia128
 newtype instance Ciphertext Camellia128 = MkCamellia128Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia128Ciphertext #-}
 pattern Camellia128Ciphertext :: ByteString -> Ciphertext Camellia128
 pattern Camellia128Ciphertext bs = MkCamellia128Ciphertext (MkGCiphertext bs)
-
-getCamellia128Ciphertext :: Ciphertext Camellia128 -> ByteString
-getCamellia128Ciphertext (Camellia128Ciphertext bs) = bs
 
 type Camellia128Ciphertext = Ciphertext Camellia128
 
 newtype instance LazyCiphertext Camellia128 = MkCamellia128LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE Camellia128LazyCiphertext #-}
 pattern Camellia128LazyCiphertext :: Lazy.ByteString -> LazyCiphertext Camellia128
 pattern Camellia128LazyCiphertext lbs = MkCamellia128LazyCiphertext (MkGLazyCiphertext lbs)
-
-getCamellia128LazyCiphertext :: LazyCiphertext Camellia128 -> Lazy.ByteString
-getCamellia128LazyCiphertext (Camellia128LazyCiphertext bs) = bs
 
 type Camellia128LazyCiphertext = LazyCiphertext Camellia128
 
@@ -83,12 +79,12 @@ instance HasSecretKey Camellia128 where
     secretKeySpec :: SizeSpecifier (SecretKey Camellia128)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.camellia128
 
-instance (MonadRandomIO m )=> SecretKeyGen Camellia128 m where
+instance MonadRandomIO m => SecretKeyGen Camellia128 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Camellia128)
+    newSecretKey :: m (SecretKey Camellia128)
     newSecretKey = Camellia128SecretKey <$> newSized (secretKeySpec @Camellia128)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Camellia128))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Camellia128))
     newSecretKeyMaybe i = fmap Camellia128SecretKey <$> newSizedMaybe (secretKeySpec @Camellia128) i
 
 instance HasCiphertext Camellia128 where
@@ -132,6 +128,7 @@ data Camellia192
 newtype instance SecretKey Camellia192 = MkCamellia192SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia192SecretKey #-}
 pattern Camellia192SecretKey :: ByteString -> SecretKey Camellia192
 pattern Camellia192SecretKey bytes = MkCamellia192SecretKey (MkGSecretKey bytes)
 
@@ -143,22 +140,18 @@ type Camellia192SecretKey = SecretKey Camellia192
 newtype instance Ciphertext Camellia192 = MkCamellia192Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia192Ciphertext #-}
 pattern Camellia192Ciphertext :: ByteString -> Ciphertext Camellia192
 pattern Camellia192Ciphertext bs = MkCamellia192Ciphertext (MkGCiphertext bs)
-
-getCamellia192Ciphertext :: Ciphertext Camellia192 -> ByteString
-getCamellia192Ciphertext (Camellia192Ciphertext bs) = bs
 
 type Camellia192Ciphertext = Ciphertext Camellia192
 
 newtype instance LazyCiphertext Camellia192 = MkCamellia192LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE Camellia192LazyCiphertext #-}
 pattern Camellia192LazyCiphertext :: Lazy.ByteString -> LazyCiphertext Camellia192
 pattern Camellia192LazyCiphertext lbs = MkCamellia192LazyCiphertext (MkGLazyCiphertext lbs)
-
-getCamellia192LazyCiphertext :: LazyCiphertext Camellia192 -> Lazy.ByteString
-getCamellia192LazyCiphertext (Camellia192LazyCiphertext bs) = bs
 
 type Camellia192LazyCiphertext = LazyCiphertext Camellia192
 
@@ -167,12 +160,12 @@ instance HasSecretKey Camellia192 where
     secretKeySpec :: SizeSpecifier (SecretKey Camellia192)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.camellia192
 
-instance (MonadRandomIO m )=> SecretKeyGen Camellia192 m where
+instance MonadRandomIO m => SecretKeyGen Camellia192 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Camellia192)
+    newSecretKey :: m (SecretKey Camellia192)
     newSecretKey = Camellia192SecretKey <$> newSized (secretKeySpec @Camellia192)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Camellia192))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Camellia192))
     newSecretKeyMaybe i = fmap Camellia192SecretKey <$> newSizedMaybe (secretKeySpec @Camellia192) i
 
 instance HasCiphertext Camellia192 where
@@ -216,6 +209,7 @@ data Camellia256
 newtype instance SecretKey Camellia256 = MkCamellia256SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia256SecretKey #-}
 pattern Camellia256SecretKey :: ByteString -> SecretKey Camellia256
 pattern Camellia256SecretKey bytes = MkCamellia256SecretKey (MkGSecretKey bytes)
 
@@ -227,22 +221,18 @@ type Camellia256SecretKey = SecretKey Camellia256
 newtype instance Ciphertext Camellia256 = MkCamellia256Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Camellia256Ciphertext #-}
 pattern Camellia256Ciphertext :: ByteString -> Ciphertext Camellia256
 pattern Camellia256Ciphertext bs = MkCamellia256Ciphertext (MkGCiphertext bs)
-
-getCamellia256Ciphertext :: Ciphertext Camellia256 -> ByteString
-getCamellia256Ciphertext (Camellia256Ciphertext bs) = bs
 
 type Camellia256Ciphertext = Ciphertext Camellia256
 
 newtype instance LazyCiphertext Camellia256 = MkCamellia256LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE Camellia256LazyCiphertext #-}
 pattern Camellia256LazyCiphertext :: Lazy.ByteString -> LazyCiphertext Camellia256
 pattern Camellia256LazyCiphertext lbs = MkCamellia256LazyCiphertext (MkGLazyCiphertext lbs)
-
-getCamellia256LazyCiphertext :: LazyCiphertext Camellia256 -> Lazy.ByteString
-getCamellia256LazyCiphertext (Camellia256LazyCiphertext bs) = bs
 
 type Camellia256LazyCiphertext = LazyCiphertext Camellia256
 
@@ -251,12 +241,12 @@ instance HasSecretKey Camellia256 where
     secretKeySpec :: SizeSpecifier (SecretKey Camellia256)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.camellia256
 
-instance (MonadRandomIO m )=> SecretKeyGen Camellia256 m where
+instance MonadRandomIO m => SecretKeyGen Camellia256 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Camellia256)
+    newSecretKey :: m (SecretKey Camellia256)
     newSecretKey = Camellia256SecretKey <$> newSized (secretKeySpec @Camellia256)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Camellia256))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Camellia256))
     newSecretKeyMaybe i = fmap Camellia256SecretKey <$> newSizedMaybe (secretKeySpec @Camellia256) i
 
 instance HasCiphertext Camellia256 where

--- a/botan/src/Botan/BlockCipher/Class.hs
+++ b/botan/src/Botan/BlockCipher/Class.hs
@@ -1,22 +1,24 @@
-module Botan.BlockCipher.Class
-( BlockCipher(..)
-, SecretKey(..)
-, Ciphertext(..)
-, LazyCiphertext(..)
-, blockCipherEncryptProxy
-, blockCipherDecryptProxy
-, blockCipherEncryptFile
-, blockCipherDecryptFile
-, IncrementalBlockCipher(..)
-, blockCipherEncryptFileLazy
-, blockCipherDecryptFileLazy
-, unsafeBlockCipherEncrypt
-, unsafeBlockCipherDecrypt
-, unsafeBlockCipherEncryptLazy
-, unsafeBlockCipherDecryptLazy
-, BlockCipher128(..)
-, IncrementalBlockCipher128(..)
-) where
+{-# LANGUAGE DefaultSignatures #-}
+
+module Botan.BlockCipher.Class (
+    BlockCipher(..)
+  , SecretKey
+  , Ciphertext
+  , LazyCiphertext
+  , blockCipherEncryptProxy
+  , blockCipherDecryptProxy
+  , blockCipherEncryptFile
+  , blockCipherDecryptFile
+  , IncrementalBlockCipher(..)
+  , blockCipherEncryptFileLazy
+  , blockCipherDecryptFileLazy
+  , unsafeBlockCipherEncrypt
+  , unsafeBlockCipherDecrypt
+  , unsafeBlockCipherEncryptLazy
+  , unsafeBlockCipherDecryptLazy
+  , BlockCipher128
+  , IncrementalBlockCipher128
+  ) where
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -26,7 +28,6 @@ import           Data.Proxy (Proxy (..))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 
-import           Botan.RNG
 import           Botan.Types.Class
 
 -- TODO: Maybe make take Block instead of ByteString, where Block (n :: Nat) ~ ByteString | length bs == natVal n
@@ -62,7 +63,7 @@ blockCipherEncryptFile k fp = blockCipherEncrypt k <$> liftIO (ByteString.readFi
 blockCipherDecryptFile :: (BlockCipher bc, MonadIO m) => SecretKey bc -> FilePath -> m (Maybe ByteString)
 blockCipherDecryptFile k fp = blockCipherDecrypt k . unsafeDecode <$> liftIO (ByteString.readFile fp)
 
-class (BlockCipher bc, HasLazyCiphertext bc) => IncrementalBlockCipher bc where
+class HasLazyCiphertext bc => IncrementalBlockCipher bc where
     blockCipherEncryptLazy :: SecretKey bc -> Lazy.ByteString -> Maybe (LazyCiphertext bc)
     blockCipherDecryptLazy :: SecretKey bc -> LazyCiphertext bc -> Maybe Lazy.ByteString
 

--- a/botan/src/Botan/BlockCipher/DES.hs
+++ b/botan/src/Botan/BlockCipher/DES.hs
@@ -1,30 +1,29 @@
-module Botan.BlockCipher.DES
-( DES(..)
-, DESSecretKey(..)
-, pattern DESSecretKey
-, getDESSecretKey
-, DESCiphertext(..)
-, desEncrypt
-, desDecrypt
-, desEncryptLazy
-, desDecryptLazy
-, TripleDES(..)
-, TripleDESSecretKey(..)
-, pattern TripleDESSecretKey
-, getTripleDESSecretKey
-, TripleDESCiphertext(..)
-, tripleDESEncrypt
-, tripleDESDecrypt
-, tripleDESEncryptLazy
-, tripleDESDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.DES (
+    DES
+  , DESSecretKey
+  , pattern DESSecretKey
+  , getDESSecretKey
+  , DESCiphertext
+  , desEncrypt
+  , desDecrypt
+  , desEncryptLazy
+  , desDecryptLazy
+  , TripleDES
+  , TripleDESSecretKey
+  , pattern TripleDESSecretKey
+  , getTripleDESSecretKey
+  , TripleDESCiphertext
+  , tripleDESEncrypt
+  , tripleDESDecrypt
+  , tripleDESEncryptLazy
+  , tripleDESDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -39,6 +38,7 @@ data DES
 newtype instance SecretKey DES = MkDESSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE DESSecretKey #-}
 pattern DESSecretKey :: ByteString -> SecretKey DES
 pattern DESSecretKey bytes = MkDESSecretKey (MkGSecretKey bytes)
 
@@ -50,22 +50,18 @@ type DESSecretKey = SecretKey DES
 newtype instance Ciphertext DES = MkDESCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE DESCiphertext #-}
 pattern DESCiphertext :: ByteString -> Ciphertext DES
 pattern DESCiphertext bs = MkDESCiphertext (MkGCiphertext bs)
-
-getDESCiphertext :: Ciphertext DES -> ByteString
-getDESCiphertext (DESCiphertext bs) = bs
 
 type DESCiphertext = Ciphertext DES
 
 newtype instance LazyCiphertext DES = MkDESLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE DESLazyCiphertext #-}
 pattern DESLazyCiphertext :: Lazy.ByteString -> LazyCiphertext DES
 pattern DESLazyCiphertext lbs = MkDESLazyCiphertext (MkGLazyCiphertext lbs)
-
-getDESLazyCiphertext :: LazyCiphertext DES -> Lazy.ByteString
-getDESLazyCiphertext (DESLazyCiphertext bs) = bs
 
 type DESLazyCiphertext = LazyCiphertext DES
 
@@ -74,12 +70,12 @@ instance HasSecretKey DES where
     secretKeySpec :: SizeSpecifier (SecretKey DES)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.des
 
-instance (MonadRandomIO m )=> SecretKeyGen DES m where
+instance MonadRandomIO m => SecretKeyGen DES m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey DES)
+    newSecretKey :: m (SecretKey DES)
     newSecretKey = DESSecretKey <$> newSized (secretKeySpec @DES)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey DES))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey DES))
     newSecretKeyMaybe i = fmap DESSecretKey <$> newSizedMaybe (secretKeySpec @DES) i
 
 instance HasCiphertext DES where
@@ -124,6 +120,7 @@ data TripleDES
 newtype instance SecretKey TripleDES = MkTripleDESSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE TripleDESSecretKey #-}
 pattern TripleDESSecretKey :: ByteString -> SecretKey TripleDES
 pattern TripleDESSecretKey bytes = MkTripleDESSecretKey (MkGSecretKey bytes)
 
@@ -135,22 +132,18 @@ type TripleDESSecretKey = SecretKey TripleDES
 newtype instance Ciphertext TripleDES = MkTripleDESCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE TripleDESCiphertext #-}
 pattern TripleDESCiphertext :: ByteString -> Ciphertext TripleDES
 pattern TripleDESCiphertext bs = MkTripleDESCiphertext (MkGCiphertext bs)
-
-getTripleDESCiphertext :: Ciphertext TripleDES -> ByteString
-getTripleDESCiphertext (TripleDESCiphertext bs) = bs
 
 type TripleDESCiphertext = Ciphertext TripleDES
 
 newtype instance LazyCiphertext TripleDES = MkTripleDESLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE TripleDESLazyCiphertext #-}
 pattern TripleDESLazyCiphertext :: Lazy.ByteString -> LazyCiphertext TripleDES
 pattern TripleDESLazyCiphertext lbs = MkTripleDESLazyCiphertext (MkGLazyCiphertext lbs)
-
-getTripleDESLazyCiphertext :: LazyCiphertext TripleDES -> Lazy.ByteString
-getTripleDESLazyCiphertext (TripleDESLazyCiphertext bs) = bs
 
 type TripleDESLazyCiphertext = LazyCiphertext TripleDES
 
@@ -159,12 +152,12 @@ instance HasSecretKey TripleDES where
     secretKeySpec :: SizeSpecifier (SecretKey TripleDES)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.tripleDES
 
-instance (MonadRandomIO m )=> SecretKeyGen TripleDES m where
+instance MonadRandomIO m => SecretKeyGen TripleDES m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey TripleDES)
+    newSecretKey :: m (SecretKey TripleDES)
     newSecretKey = TripleDESSecretKey <$> newSized (secretKeySpec @TripleDES)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey TripleDES))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey TripleDES))
     newSecretKeyMaybe i = fmap TripleDESSecretKey <$> newSizedMaybe (secretKeySpec @TripleDES) i
 
 instance HasCiphertext TripleDES where

--- a/botan/src/Botan/BlockCipher/GOST.hs
+++ b/botan/src/Botan/BlockCipher/GOST.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.GOST
-( GOST_28147_89(..)
-, GOST_28147_89SecretKey(..)
-, pattern GOST_28147_89SecretKey
-, getGOST_28147_89SecretKey
-, GOST_28147_89Ciphertext(..)
-, gost_28147_89Encrypt
-, gost_28147_89Decrypt
-, gost_28147_89EncryptLazy
-, gost_28147_89DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.GOST (
+    GOST_28147_89
+  , GOST_28147_89SecretKey
+  , pattern GOST_28147_89SecretKey
+  , getGOST_28147_89SecretKey
+  , GOST_28147_89Ciphertext
+  , gost_28147_89Encrypt
+  , gost_28147_89Decrypt
+  , gost_28147_89EncryptLazy
+  , gost_28147_89DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data GOST_28147_89
 newtype instance SecretKey GOST_28147_89 = MkGOST_28147_89SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE GOST_28147_89SecretKey #-}
 pattern GOST_28147_89SecretKey :: ByteString -> SecretKey GOST_28147_89
 pattern GOST_28147_89SecretKey bytes = MkGOST_28147_89SecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,19 @@ type GOST_28147_89SecretKey = SecretKey GOST_28147_89
 newtype instance Ciphertext GOST_28147_89 = MkGOST_28147_89Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE GOST_28147_89Ciphertext #-}
 pattern GOST_28147_89Ciphertext :: ByteString -> Ciphertext GOST_28147_89
 pattern GOST_28147_89Ciphertext bs = MkGOST_28147_89Ciphertext (MkGCiphertext bs)
-
-getGOST_28147_89Ciphertext :: Ciphertext GOST_28147_89 -> ByteString
-getGOST_28147_89Ciphertext (GOST_28147_89Ciphertext bs) = bs
 
 type GOST_28147_89Ciphertext = Ciphertext GOST_28147_89
 
 newtype instance LazyCiphertext GOST_28147_89 = MkGOST_28147_89LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE GOST_28147_89LazyCiphertext #-}
 pattern GOST_28147_89LazyCiphertext :: Lazy.ByteString -> LazyCiphertext GOST_28147_89
 pattern GOST_28147_89LazyCiphertext lbs = MkGOST_28147_89LazyCiphertext (MkGLazyCiphertext lbs)
 
-getGOST_28147_89LazyCiphertext :: LazyCiphertext GOST_28147_89 -> Lazy.ByteString
-getGOST_28147_89LazyCiphertext (GOST_28147_89LazyCiphertext bs) = bs
 
 type GOST_28147_89LazyCiphertext = LazyCiphertext GOST_28147_89
 
@@ -65,12 +62,12 @@ instance HasSecretKey GOST_28147_89 where
     secretKeySpec :: SizeSpecifier (SecretKey GOST_28147_89)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.gost_28147_89
 
-instance (MonadRandomIO m )=> SecretKeyGen GOST_28147_89 m where
+instance MonadRandomIO m => SecretKeyGen GOST_28147_89 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey GOST_28147_89)
+    newSecretKey :: m (SecretKey GOST_28147_89)
     newSecretKey = GOST_28147_89SecretKey <$> newSized (secretKeySpec @GOST_28147_89)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey GOST_28147_89))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey GOST_28147_89))
     newSecretKeyMaybe i = fmap GOST_28147_89SecretKey <$> newSizedMaybe (secretKeySpec @GOST_28147_89) i
 
 instance HasCiphertext GOST_28147_89 where

--- a/botan/src/Botan/BlockCipher/IDEA.hs
+++ b/botan/src/Botan/BlockCipher/IDEA.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.IDEA
-( IDEA(..)
-, IDEASecretKey(..)
-, pattern IDEASecretKey
-, getIDEASecretKey
-, IDEACiphertext(..)
-, ideaEncrypt
-, ideaDecrypt
-, ideaEncryptLazy
-, ideaDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.IDEA (
+    IDEA
+  , IDEASecretKey
+  , pattern IDEASecretKey
+  , getIDEASecretKey
+  , IDEACiphertext
+  , ideaEncrypt
+  , ideaDecrypt
+  , ideaEncryptLazy
+  , ideaDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data IDEA
 newtype instance SecretKey IDEA = MkIDEASecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE IDEASecretKey #-}
 pattern IDEASecretKey :: ByteString -> SecretKey IDEA
 pattern IDEASecretKey bytes = MkIDEASecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type IDEASecretKey = SecretKey IDEA
 newtype instance Ciphertext IDEA = MkIDEACiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE IDEACiphertext #-}
 pattern IDEACiphertext :: ByteString -> Ciphertext IDEA
 pattern IDEACiphertext bs = MkIDEACiphertext (MkGCiphertext bs)
-
-getIDEACiphertext :: Ciphertext IDEA -> ByteString
-getIDEACiphertext (IDEACiphertext bs) = bs
 
 type IDEACiphertext = Ciphertext IDEA
 
 newtype instance LazyCiphertext IDEA = MkIDEALazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE IDEALazyCiphertext #-}
 pattern IDEALazyCiphertext :: Lazy.ByteString -> LazyCiphertext IDEA
 pattern IDEALazyCiphertext lbs = MkIDEALazyCiphertext (MkGLazyCiphertext lbs)
-
-getIDEALazyCiphertext :: LazyCiphertext IDEA -> Lazy.ByteString
-getIDEALazyCiphertext (IDEALazyCiphertext bs) = bs
 
 type IDEALazyCiphertext = LazyCiphertext IDEA
 
@@ -65,12 +61,12 @@ instance HasSecretKey IDEA where
     secretKeySpec :: SizeSpecifier (SecretKey IDEA)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.idea
 
-instance (MonadRandomIO m )=> SecretKeyGen IDEA m where
+instance MonadRandomIO m => SecretKeyGen IDEA m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey IDEA)
+    newSecretKey :: m (SecretKey IDEA)
     newSecretKey = IDEASecretKey <$> newSized (secretKeySpec @IDEA)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey IDEA))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey IDEA))
     newSecretKeyMaybe i = fmap IDEASecretKey <$> newSizedMaybe (secretKeySpec @IDEA) i
 
 instance HasCiphertext IDEA where

--- a/botan/src/Botan/BlockCipher/Noekeon.hs
+++ b/botan/src/Botan/BlockCipher/Noekeon.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.Noekeon
-( Noekeon(..)
-, NoekeonSecretKey(..)
-, pattern NoekeonSecretKey
-, getNoekeonSecretKey
-, NoekeonCiphertext(..)
-, noekeonEncrypt
-, noekeonDecrypt
-, noekeonEncryptLazy
-, noekeonDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Noekeon (
+    Noekeon
+  , NoekeonSecretKey
+  , pattern NoekeonSecretKey
+  , getNoekeonSecretKey
+  , NoekeonCiphertext
+  , noekeonEncrypt
+  , noekeonDecrypt
+  , noekeonEncryptLazy
+  , noekeonDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data Noekeon
 newtype instance SecretKey Noekeon = MkNoekeonSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE NoekeonSecretKey #-}
 pattern NoekeonSecretKey :: ByteString -> SecretKey Noekeon
 pattern NoekeonSecretKey bytes = MkNoekeonSecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type NoekeonSecretKey = SecretKey Noekeon
 newtype instance Ciphertext Noekeon = MkNoekeonCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE NoekeonCiphertext #-}
 pattern NoekeonCiphertext :: ByteString -> Ciphertext Noekeon
 pattern NoekeonCiphertext bs = MkNoekeonCiphertext (MkGCiphertext bs)
-
-getNoekeonCiphertext :: Ciphertext Noekeon -> ByteString
-getNoekeonCiphertext (NoekeonCiphertext bs) = bs
 
 type NoekeonCiphertext = Ciphertext Noekeon
 
 newtype instance LazyCiphertext Noekeon = MkNoekeonLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE NoekeonLazyCiphertext #-}
 pattern NoekeonLazyCiphertext :: Lazy.ByteString -> LazyCiphertext Noekeon
 pattern NoekeonLazyCiphertext lbs = MkNoekeonLazyCiphertext (MkGLazyCiphertext lbs)
-
-getNoekeonLazyCiphertext :: LazyCiphertext Noekeon -> Lazy.ByteString
-getNoekeonLazyCiphertext (NoekeonLazyCiphertext bs) = bs
 
 type NoekeonLazyCiphertext = LazyCiphertext Noekeon
 
@@ -65,12 +61,12 @@ instance HasSecretKey Noekeon where
     secretKeySpec :: SizeSpecifier (SecretKey Noekeon)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.noekeon
 
-instance (MonadRandomIO m )=> SecretKeyGen Noekeon m where
+instance MonadRandomIO m => SecretKeyGen Noekeon m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Noekeon)
+    newSecretKey :: m (SecretKey Noekeon)
     newSecretKey = NoekeonSecretKey <$> newSized (secretKeySpec @Noekeon)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Noekeon))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Noekeon))
     newSecretKeyMaybe i = fmap NoekeonSecretKey <$> newSizedMaybe (secretKeySpec @Noekeon) i
 
 instance HasCiphertext Noekeon where

--- a/botan/src/Botan/BlockCipher/SEED.hs
+++ b/botan/src/Botan/BlockCipher/SEED.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.SEED
-( SEED(..)
-, SEEDSecretKey(..)
-, pattern SEEDSecretKey
-, getSEEDSecretKey
-, SEEDCiphertext(..)
-, seedEncrypt
-, seedDecrypt
-, seedEncryptLazy
-, seedDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.SEED (
+    SEED
+  , SEEDSecretKey
+  , pattern SEEDSecretKey
+  , getSEEDSecretKey
+  , SEEDCiphertext
+  , seedEncrypt
+  , seedDecrypt
+  , seedEncryptLazy
+  , seedDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data SEED
 newtype instance SecretKey SEED = MkSEEDSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SEEDSecretKey #-}
 pattern SEEDSecretKey :: ByteString -> SecretKey SEED
 pattern SEEDSecretKey bytes = MkSEEDSecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type SEEDSecretKey = SecretKey SEED
 newtype instance Ciphertext SEED = MkSEEDCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SEEDCiphertext #-}
 pattern SEEDCiphertext :: ByteString -> Ciphertext SEED
 pattern SEEDCiphertext bs = MkSEEDCiphertext (MkGCiphertext bs)
-
-getSEEDCiphertext :: Ciphertext SEED -> ByteString
-getSEEDCiphertext (SEEDCiphertext bs) = bs
 
 type SEEDCiphertext = Ciphertext SEED
 
 newtype instance LazyCiphertext SEED = MkSEEDLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE SEEDLazyCiphertext #-}
 pattern SEEDLazyCiphertext :: Lazy.ByteString -> LazyCiphertext SEED
 pattern SEEDLazyCiphertext lbs = MkSEEDLazyCiphertext (MkGLazyCiphertext lbs)
-
-getSEEDLazyCiphertext :: LazyCiphertext SEED -> Lazy.ByteString
-getSEEDLazyCiphertext (SEEDLazyCiphertext bs) = bs
 
 type SEEDLazyCiphertext = LazyCiphertext SEED
 
@@ -65,12 +61,12 @@ instance HasSecretKey SEED where
     secretKeySpec :: SizeSpecifier (SecretKey SEED)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.seed
 
-instance (MonadRandomIO m )=> SecretKeyGen SEED m where
+instance MonadRandomIO m => SecretKeyGen SEED m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey SEED)
+    newSecretKey :: m (SecretKey SEED)
     newSecretKey = SEEDSecretKey <$> newSized (secretKeySpec @SEED)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey SEED))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey SEED))
     newSecretKeyMaybe i = fmap SEEDSecretKey <$> newSizedMaybe (secretKeySpec @SEED) i
 
 instance HasCiphertext SEED where

--- a/botan/src/Botan/BlockCipher/SHALCAL.hs
+++ b/botan/src/Botan/BlockCipher/SHALCAL.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.SHALCAL
-( SHALCAL2(..)
-, SHALCAL2SecretKey(..)
-, pattern SHALCAL2SecretKey
-, getSHALCAL2SecretKey
-, SHALCAL2Ciphertext(..)
-, shalcal2Encrypt
-, shalcal2Decrypt
-, shalcal2EncryptLazy
-, shalcal2DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.SHALCAL (
+    SHALCAL2
+  , SHALCAL2SecretKey
+  , pattern SHALCAL2SecretKey
+  , getSHALCAL2SecretKey
+  , SHALCAL2Ciphertext
+  , shalcal2Encrypt
+  , shalcal2Decrypt
+  , shalcal2EncryptLazy
+  , shalcal2DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data SHALCAL2
 newtype instance SecretKey SHALCAL2 = MkSHALCAL2SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SHALCAL2SecretKey #-}
 pattern SHALCAL2SecretKey :: ByteString -> SecretKey SHALCAL2
 pattern SHALCAL2SecretKey bytes = MkSHALCAL2SecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type SHALCAL2SecretKey = SecretKey SHALCAL2
 newtype instance Ciphertext SHALCAL2 = MkSHALCAL2Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SHALCAL2Ciphertext #-}
 pattern SHALCAL2Ciphertext :: ByteString -> Ciphertext SHALCAL2
 pattern SHALCAL2Ciphertext bs = MkSHALCAL2Ciphertext (MkGCiphertext bs)
-
-getSHALCAL2Ciphertext :: Ciphertext SHALCAL2 -> ByteString
-getSHALCAL2Ciphertext (SHALCAL2Ciphertext bs) = bs
 
 type SHALCAL2Ciphertext = Ciphertext SHALCAL2
 
 newtype instance LazyCiphertext SHALCAL2 = MkSHALCAL2LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE SHALCAL2LazyCiphertext #-}
 pattern SHALCAL2LazyCiphertext :: Lazy.ByteString -> LazyCiphertext SHALCAL2
 pattern SHALCAL2LazyCiphertext lbs = MkSHALCAL2LazyCiphertext (MkGLazyCiphertext lbs)
-
-getSHALCAL2LazyCiphertext :: LazyCiphertext SHALCAL2 -> Lazy.ByteString
-getSHALCAL2LazyCiphertext (SHALCAL2LazyCiphertext bs) = bs
 
 type SHALCAL2LazyCiphertext = LazyCiphertext SHALCAL2
 
@@ -65,12 +61,12 @@ instance HasSecretKey SHALCAL2 where
     secretKeySpec :: SizeSpecifier (SecretKey SHALCAL2)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.shalcal2
 
-instance (MonadRandomIO m )=> SecretKeyGen SHALCAL2 m where
+instance MonadRandomIO m => SecretKeyGen SHALCAL2 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey SHALCAL2)
+    newSecretKey :: m (SecretKey SHALCAL2)
     newSecretKey = SHALCAL2SecretKey <$> newSized (secretKeySpec @SHALCAL2)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey SHALCAL2))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey SHALCAL2))
     newSecretKeyMaybe i = fmap SHALCAL2SecretKey <$> newSizedMaybe (secretKeySpec @SHALCAL2) i
 
 instance HasCiphertext SHALCAL2 where

--- a/botan/src/Botan/BlockCipher/SM4.hs
+++ b/botan/src/Botan/BlockCipher/SM4.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.SM4
-( SM4(..)
-, SM4SecretKey(..)
-, pattern SM4SecretKey
-, getSM4SecretKey
-, SM4Ciphertext(..)
-, sm4Encrypt
-, sm4Decrypt
-, sm4EncryptLazy
-, sm4DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.SM4 (
+    SM4
+  , SM4SecretKey
+  , pattern SM4SecretKey
+  , getSM4SecretKey
+  , SM4Ciphertext
+  , sm4Encrypt
+  , sm4Decrypt
+  , sm4EncryptLazy
+  , sm4DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data SM4
 newtype instance SecretKey SM4 = MkSM4SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SM4SecretKey #-}
 pattern SM4SecretKey :: ByteString -> SecretKey SM4
 pattern SM4SecretKey bytes = MkSM4SecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type SM4SecretKey = SecretKey SM4
 newtype instance Ciphertext SM4 = MkSM4Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SM4Ciphertext #-}
 pattern SM4Ciphertext :: ByteString -> Ciphertext SM4
 pattern SM4Ciphertext bs = MkSM4Ciphertext (MkGCiphertext bs)
-
-getSM4Ciphertext :: Ciphertext SM4 -> ByteString
-getSM4Ciphertext (SM4Ciphertext bs) = bs
 
 type SM4Ciphertext = Ciphertext SM4
 
 newtype instance LazyCiphertext SM4 = MkSM4LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE SM4LazyCiphertext #-}
 pattern SM4LazyCiphertext :: Lazy.ByteString -> LazyCiphertext SM4
 pattern SM4LazyCiphertext lbs = MkSM4LazyCiphertext (MkGLazyCiphertext lbs)
-
-getSM4LazyCiphertext :: LazyCiphertext SM4 -> Lazy.ByteString
-getSM4LazyCiphertext (SM4LazyCiphertext bs) = bs
 
 type SM4LazyCiphertext = LazyCiphertext SM4
 
@@ -65,12 +61,12 @@ instance HasSecretKey SM4 where
     secretKeySpec :: SizeSpecifier (SecretKey SM4)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.sm4
 
-instance (MonadRandomIO m )=> SecretKeyGen SM4 m where
+instance MonadRandomIO m => SecretKeyGen SM4 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey SM4)
+    newSecretKey :: m (SecretKey SM4)
     newSecretKey = SM4SecretKey <$> newSized (secretKeySpec @SM4)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey SM4))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey SM4))
     newSecretKeyMaybe i = fmap SM4SecretKey <$> newSizedMaybe (secretKeySpec @SM4) i
 
 instance HasCiphertext SM4 where

--- a/botan/src/Botan/BlockCipher/Serpent.hs
+++ b/botan/src/Botan/BlockCipher/Serpent.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.Serpent
-( Serpent(..)
-, SerpentSecretKey(..)
-, pattern SerpentSecretKey
-, getSerpentSecretKey
-, SerpentCiphertext(..)
-, serpentEncrypt
-, serpentDecrypt
-, serpentEncryptLazy
-, serpentDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Serpent (
+    Serpent
+  , SerpentSecretKey
+  , pattern SerpentSecretKey
+  , getSerpentSecretKey
+  , SerpentCiphertext
+  , serpentEncrypt
+  , serpentDecrypt
+  , serpentEncryptLazy
+  , serpentDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data Serpent
 newtype instance SecretKey Serpent = MkSerpentSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SerpentSecretKey #-}
 pattern SerpentSecretKey :: ByteString -> SecretKey Serpent
 pattern SerpentSecretKey bytes = MkSerpentSecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type SerpentSecretKey = SecretKey Serpent
 newtype instance Ciphertext Serpent = MkSerpentCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE SerpentCiphertext #-}
 pattern SerpentCiphertext :: ByteString -> Ciphertext Serpent
 pattern SerpentCiphertext bs = MkSerpentCiphertext (MkGCiphertext bs)
-
-getSerpentCiphertext :: Ciphertext Serpent -> ByteString
-getSerpentCiphertext (SerpentCiphertext bs) = bs
 
 type SerpentCiphertext = Ciphertext Serpent
 
 newtype instance LazyCiphertext Serpent = MkSerpentLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE SerpentLazyCiphertext #-}
 pattern SerpentLazyCiphertext :: Lazy.ByteString -> LazyCiphertext Serpent
 pattern SerpentLazyCiphertext lbs = MkSerpentLazyCiphertext (MkGLazyCiphertext lbs)
-
-getSerpentLazyCiphertext :: LazyCiphertext Serpent -> Lazy.ByteString
-getSerpentLazyCiphertext (SerpentLazyCiphertext bs) = bs
 
 type SerpentLazyCiphertext = LazyCiphertext Serpent
 
@@ -65,12 +61,12 @@ instance HasSecretKey Serpent where
     secretKeySpec :: SizeSpecifier (SecretKey Serpent)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.serpent
 
-instance (MonadRandomIO m )=> SecretKeyGen Serpent m where
+instance MonadRandomIO m => SecretKeyGen Serpent m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Serpent)
+    newSecretKey :: m (SecretKey Serpent)
     newSecretKey = SerpentSecretKey <$> newSized (secretKeySpec @Serpent)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Serpent))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Serpent))
     newSecretKeyMaybe i = fmap SerpentSecretKey <$> newSizedMaybe (secretKeySpec @Serpent) i
 
 instance HasCiphertext Serpent where

--- a/botan/src/Botan/BlockCipher/Threefish.hs
+++ b/botan/src/Botan/BlockCipher/Threefish.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.Threefish
-( Threefish512(..)
-, Threefish512SecretKey(..)
-, pattern Threefish512SecretKey
-, getThreefish512SecretKey
-, Threefish512Ciphertext(..)
-, threefish512Encrypt
-, threefish512Decrypt
-, threefish512EncryptLazy
-, threefish512DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Threefish (
+    Threefish512
+  , Threefish512SecretKey
+  , pattern Threefish512SecretKey
+  , getThreefish512SecretKey
+  , Threefish512Ciphertext
+  , threefish512Encrypt
+  , threefish512Decrypt
+  , threefish512EncryptLazy
+  , threefish512DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data Threefish512
 newtype instance SecretKey Threefish512 = MkThreefish512SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Threefish512SecretKey #-}
 pattern Threefish512SecretKey :: ByteString -> SecretKey Threefish512
 pattern Threefish512SecretKey bytes = MkThreefish512SecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type Threefish512SecretKey = SecretKey Threefish512
 newtype instance Ciphertext Threefish512 = MkThreefish512Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE Threefish512Ciphertext #-}
 pattern Threefish512Ciphertext :: ByteString -> Ciphertext Threefish512
 pattern Threefish512Ciphertext bs = MkThreefish512Ciphertext (MkGCiphertext bs)
-
-getThreefish512Ciphertext :: Ciphertext Threefish512 -> ByteString
-getThreefish512Ciphertext (Threefish512Ciphertext bs) = bs
 
 type Threefish512Ciphertext = Ciphertext Threefish512
 
 newtype instance LazyCiphertext Threefish512 = MkThreefish512LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE Threefish512LazyCiphertext #-}
 pattern Threefish512LazyCiphertext :: Lazy.ByteString -> LazyCiphertext Threefish512
 pattern Threefish512LazyCiphertext lbs = MkThreefish512LazyCiphertext (MkGLazyCiphertext lbs)
-
-getThreefish512LazyCiphertext :: LazyCiphertext Threefish512 -> Lazy.ByteString
-getThreefish512LazyCiphertext (Threefish512LazyCiphertext bs) = bs
 
 type Threefish512LazyCiphertext = LazyCiphertext Threefish512
 
@@ -65,12 +61,12 @@ instance HasSecretKey Threefish512 where
     secretKeySpec :: SizeSpecifier (SecretKey Threefish512)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.threefish512
 
-instance (MonadRandomIO m )=> SecretKeyGen Threefish512 m where
+instance MonadRandomIO m => SecretKeyGen Threefish512 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Threefish512)
+    newSecretKey :: m (SecretKey Threefish512)
     newSecretKey = Threefish512SecretKey <$> newSized (secretKeySpec @Threefish512)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Threefish512))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Threefish512))
     newSecretKeyMaybe i = fmap Threefish512SecretKey <$> newSizedMaybe (secretKeySpec @Threefish512) i
 
 instance HasCiphertext Threefish512 where

--- a/botan/src/Botan/BlockCipher/Twofish.hs
+++ b/botan/src/Botan/BlockCipher/Twofish.hs
@@ -1,21 +1,20 @@
-module Botan.BlockCipher.Twofish
-( Twofish(..)
-, TwofishSecretKey(..)
-, pattern TwofishSecretKey
-, getTwofishSecretKey
-, TwofishCiphertext(..)
-, twofishEncrypt
-, twofishDecrypt
-, twofishEncryptLazy
-, twofishDecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.BlockCipher.Twofish (
+    Twofish
+  , TwofishSecretKey
+  , pattern TwofishSecretKey
+  , getTwofishSecretKey
+  , TwofishCiphertext
+  , twofishEncrypt
+  , twofishDecrypt
+  , twofishEncryptLazy
+  , twofishDecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.BlockCipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -30,6 +29,7 @@ data Twofish
 newtype instance SecretKey Twofish = MkTwofishSecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE TwofishSecretKey #-}
 pattern TwofishSecretKey :: ByteString -> SecretKey Twofish
 pattern TwofishSecretKey bytes = MkTwofishSecretKey (MkGSecretKey bytes)
 
@@ -41,22 +41,18 @@ type TwofishSecretKey = SecretKey Twofish
 newtype instance Ciphertext Twofish = MkTwofishCiphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE TwofishCiphertext #-}
 pattern TwofishCiphertext :: ByteString -> Ciphertext Twofish
 pattern TwofishCiphertext bs = MkTwofishCiphertext (MkGCiphertext bs)
-
-getTwofishCiphertext :: Ciphertext Twofish -> ByteString
-getTwofishCiphertext (TwofishCiphertext bs) = bs
 
 type TwofishCiphertext = Ciphertext Twofish
 
 newtype instance LazyCiphertext Twofish = MkTwofishLazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE TwofishLazyCiphertext #-}
 pattern TwofishLazyCiphertext :: Lazy.ByteString -> LazyCiphertext Twofish
 pattern TwofishLazyCiphertext lbs = MkTwofishLazyCiphertext (MkGLazyCiphertext lbs)
-
-getTwofishLazyCiphertext :: LazyCiphertext Twofish -> Lazy.ByteString
-getTwofishLazyCiphertext (TwofishLazyCiphertext bs) = bs
 
 type TwofishLazyCiphertext = LazyCiphertext Twofish
 
@@ -65,12 +61,12 @@ instance HasSecretKey Twofish where
     secretKeySpec :: SizeSpecifier (SecretKey Twofish)
     secretKeySpec = coerceSizeSpec $ Botan.blockCipherKeySpec Botan.twofish
 
-instance (MonadRandomIO m )=> SecretKeyGen Twofish m where
+instance MonadRandomIO m => SecretKeyGen Twofish m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey Twofish)
+    newSecretKey :: m (SecretKey Twofish)
     newSecretKey = TwofishSecretKey <$> newSized (secretKeySpec @Twofish)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey Twofish))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey Twofish))
     newSecretKeyMaybe i = fmap TwofishSecretKey <$> newSizedMaybe (secretKeySpec @Twofish) i
 
 instance HasCiphertext Twofish where

--- a/botan/src/Botan/Checksum/Adler.hs
+++ b/botan/src/Botan/Checksum/Adler.hs
@@ -1,11 +1,12 @@
-module Botan.Checksum.Adler
-( Adler32(..)
-, Adler32Digest(..)
-, adler32
-, adler32Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Checksum.Adler (
+    Adler32
+  , Adler32Digest
+  , adler32
+  , adler32Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data Adler32
 
 newtype instance Digest Adler32 = Adler32Digest
-    { getAdler32ByteString :: ByteString {- ByteVector n -} }
+    { _getAdler32ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type Adler32Digest = Digest Adler32

--- a/botan/src/Botan/Checksum/CRC.hs
+++ b/botan/src/Botan/Checksum/CRC.hs
@@ -1,15 +1,16 @@
-module Botan.Checksum.CRC
-( CRC24(..)
-, CRC24Digest(..)
-, crc24
-, crc24Lazy
-, CRC32(..)
-, CRC32Digest(..)
-, crc32
-, crc32Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Checksum.CRC (
+    CRC24
+  , CRC24Digest
+  , crc24
+  , crc24Lazy
+  , CRC32
+  , CRC32Digest
+  , crc32
+  , crc32Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -24,7 +25,7 @@ import           Botan.Prelude
 data CRC24
 
 newtype instance Digest CRC24 = CRC24Digest
-    { getCRC24ByteString :: ByteString {- ByteVector n -} }
+    { _getCRC24ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type CRC24Digest = Digest CRC24
@@ -54,7 +55,7 @@ crc24Lazy = hashLazy
 data CRC32
 
 newtype instance Digest CRC32 = CRC32Digest
-    { getCRC32ByteString :: ByteString {- ByteVector n -} }
+    { _getCRC32ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type CRC32Digest = Digest CRC32

--- a/botan/src/Botan/Cipher.hs
+++ b/botan/src/Botan/Cipher.hs
@@ -17,137 +17,134 @@ a mode of operation applies the block cipher’s single block operation
 repeatedly to encrypt an entire message.
 -}
 
-module Botan.Cipher
-(
+module Botan.Cipher (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Idiomatic interface
+  -- * Idiomatic interface
 
--- ** Cipher data type
- Cipher(..)
+  -- ** Cipher data type
+  Cipher(..)
 
--- ** AEAD data type
-, AEAD(..)
-, aead
-, unsafeAEAD
-, isAEAD
+  -- ** AEAD data type
+  , AEAD(..)
+  , aead
+  , unsafeAEAD
+  , isAEAD
 
--- ** Enumerations
+  -- ** Enumerations
 
-, ciphers
-, cbcPaddings
-, aeads
+  , ciphers
+  , cbcPaddings
+  , aeads
 
--- ** Associated types
-, CipherKey(..)
-, CipherNonce(..)
-, CBCPadding(..)
-, AEADAssociatedData(..)
+  -- ** Associated types
+  , CipherKey
+  , CipherNonce
+  , CBCPadding(..)
+  , AEADAssociatedData
 
--- ** Accessors
+  -- ** Accessors
 
-, cipherName
-, cipherKeySpec
-, cipherDefaultNonceSize
-, cipherNonceSizeIsValid
-, cipherTagSize
-, cipherUpdateGranularity
-, cipherIdealUpdateGranularity
--- NOTE: This is our custom function
--- , cipherEstimateOutputLength
--- TODO: Determine if this function is state-dependent
--- NOTE: Really returns an upper bound but is not accurate? Can't remember, notes are old.
-, cipherOutputLength
+  , cipherName
+  , cipherKeySpec
+  , cipherDefaultNonceSize
+  , cipherNonceSizeIsValid
+  , cipherTagSize
+  , cipherUpdateGranularity
+  , cipherIdealUpdateGranularity
+  -- NOTE: This is our custom function
+  -- , cipherEstimateOutputLength
+  -- TODO: Determine if this function is state-dependent
+  -- NOTE: Really returns an upper bound but is not accurate? Can't remember, notes are old.
+  , cipherOutputLength
 
--- ** Idiomatic algorithm
-, cipherEncrypt   -- NOTE: Offline
-, cipherDecrypt
-, cipherEncryptLazy
-, cipherDecryptLazy
--- , encryptGeneratingKeys
--- , autoEncrypt
+  -- ** Idiomatic algorithm
+  , cipherEncrypt   -- NOTE: Offline
+  , cipherDecrypt
+  , cipherEncryptLazy
+  , cipherDecryptLazy
+  -- , encryptGeneratingKeys
+  -- , autoEncrypt
 
-, aeadEncrypt
-, aeadDecrypt
+  , aeadEncrypt
+  , aeadDecrypt
 
--- encryptLazy -- NOTE: Online, SIV and CCM are not available
--- , decryptLazy
+  -- encryptLazy -- NOTE: Online, SIV and CCM are not available
+  -- , decryptLazy
 
--- * Mutable interface
+  -- * Mutable interface
 
--- ** Tagged mutable context
--- TODO: Split MutableCipher into MutableEncipher and MutableDecipher?
--- Would be separate like pk ops
-, MutableCipher(..)
+  -- ** Tagged mutable context
+  -- TODO: Split MutableCipher into MutableEncipher and MutableDecipher?
+  -- Would be separate like pk ops
+  , MutableCipher(..)
 
--- ** Destructor
-, destroyCipher
+  -- ** Destructor
+  , destroyCipher
 
--- ** Associated types
-, CipherDirection(..)
-, CipherUpdate(..)
+  -- ** Associated types
+  , CipherDirection(..)
+  , CipherUpdate(..)
 
--- ** Initializers
-, newCipher
+  -- ** Initializers
+  , newCipher
 
--- ** Accessors
-, getCipherName
-, getCipherKeySpec
-, getCipherDefaultNonceSize
-, getCipherNonceSizeIsValid
-, getCipherTagSize
-, getCipherUpdateGranularity
-, getCipherIdealUpdateGranularity
-, getCipherEstimateOutputLength
-, getCipherOutputLength
-, setCipherKey
-, setAEADAssociatedData
+  -- ** Accessors
+  , getCipherName
+  , getCipherKeySpec
+  , getCipherDefaultNonceSize
+  , getCipherNonceSizeIsValid
+  , getCipherTagSize
+  , getCipherUpdateGranularity
+  , getCipherIdealUpdateGranularity
+  , getCipherEstimateOutputLength
+  , getCipherOutputLength
+  , setCipherKey
+  , setAEADAssociatedData
 
--- ** Accessory functions
-, clearCipher
-, resetCipher
+  -- ** Accessory functions
+  , clearCipher
+  , resetCipher
 
--- ** Mutable algorithm
-, startCipher
-, updateCipher
--- , updateCipherChunks
-, finalizeCipher
-, finalizeResetCipher
-, finalizeClearCipher
+  -- ** Mutable algorithm
+  , startCipher
+  , updateCipher
+  -- , updateCipherChunks
+  , finalizeCipher
+  , finalizeResetCipher
+  , finalizeClearCipher
 
--- ** Algorithm references
+  -- ** Algorithm references
 
-, cbc
-, cbcWith
-, cfb
-, cfbWith
-, xts
-, chaCha20Poly1305
-, gcm
-, gcmWith
-, ocb
-, ocbWith
-, eax
-, eaxWith
-, siv
-, ccm
-, ccmWith
+  , cbc
+  , cbcWith
+  , cfb
+  , cfbWith
+  , xts
+  , chaCha20Poly1305
+  , gcm
+  , gcmWith
+  , ocb
+  , ocbWith
+  , eax
+  , eaxWith
+  , siv
+  , ccm
+  , ccmWith
 
-) where
+  ) where
 
 import qualified Botan.Low.Cipher as Low
 
 import           Botan.BlockCipher
-import           Botan.Error
 import           Botan.KeySpec
 import           Botan.Prelude
 
-import           Botan.RNG
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 
@@ -202,7 +199,7 @@ data Cipher
     | EAX BlockCipher Int -- Tag size, default is block size
     | SIV BlockCipher128
     | CCM BlockCipher128 Int Int -- Tag size and L, default tag size is 16 and L is 3
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 -- CBC Padding - does this have use elsewhere?
 data CBCPadding
@@ -212,14 +209,14 @@ data CBCPadding
     | ESP   -- NOTE: RFC 4304
     | CTS   -- NOTE: Ciphertext stealing
     | NoPadding
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 -- TODO: AE data type? Unnecessary if considering AEAD?
 
 -- AEAD data type
 
 newtype AEAD = MkAEAD { unAEAD :: Cipher }
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 aead :: Cipher -> Maybe AEAD
 aead c@(ChaCha20Poly1305) = Just $ MkAEAD c
@@ -272,21 +269,7 @@ type CipherKeySpec = KeySpec
 
 type CipherKey = Low.CipherKey
 
-newCipherKey :: (MonadRandomIO m) => Cipher -> m CipherKey
-newCipherKey = newKey . cipherKeySpec
-
-newCipherKeyMaybe :: (MonadRandomIO m) => Int -> Cipher -> m (Maybe CipherKey)
-newCipherKeyMaybe sz bc = newKeyMaybe sz (cipherKeySpec bc)
-
 type CipherNonce = ByteString
-
-newCipherNonce :: (MonadRandomIO m) => Cipher -> m CipherNonce
-newCipherNonce = getRandomBytes . cipherDefaultNonceSize
-
-newCipherNonceMaybe :: (MonadRandomIO m) => Int -> Cipher -> m (Maybe CipherNonce)
-newCipherNonceMaybe sz c = if cipherNonceSizeIsValid sz c
-    then Just <$> getRandomBytes sz
-    else return Nothing
 
 type AEADAssociatedData = ByteString
 
@@ -310,9 +293,6 @@ cbcPaddingName X9_23       = Low.X9_23
 cbcPaddingName ESP         = Low.ESP
 cbcPaddingName CTS         = Low.CTS
 cbcPaddingName NoPadding   = Low.NoPadding
-
-aeadName :: AEAD -> Low.CipherName
-aeadName = cipherName . unAEAD
 
 cipherKeySpec :: Cipher -> CipherKeySpec
 cipherKeySpec (CBC bc _)        = blockCipherKeySpec bc
@@ -381,7 +361,7 @@ cipherNonceSizeIsValid :: Int -> Cipher -> Bool
 cipherNonceSizeIsValid n (CBC bc _)         = n == blockCipherBlockSize bc
 cipherNonceSizeIsValid n (CFB bc _)         = n == blockCipherBlockSize bc
 cipherNonceSizeIsValid n (XTS bc)           = 1 <= n && n <= blockCipherBlockSize bc -- Always [ 1 .. 16 ]
-cipherNonceSizeIsValid n chaCha20Poly1305   = n `elem` [ 8, 12, 24 ]
+cipherNonceSizeIsValid n _haCha20Poly1305   = n `elem` [ 8, 12, 24 ]
 cipherNonceSizeIsValid n (GCM _ _)          = 1 <= n && n <= internalMaximumCipherNonceSize -- True if unbounded
 cipherNonceSizeIsValid n (OCB bc128 _)      = 1 <= n && n <= blockCipherBlockSize (unBlockCipher128 bc128) - 1 -- Always [ 1 .. 15 ]
 cipherNonceSizeIsValid n (EAX _ _)          = 1 <= n && n <= internalMaximumCipherNonceSize -- True if unbounded
@@ -406,15 +386,15 @@ generateCipherNonceLengths = do
 -}
 
 cipherTagSize :: Cipher -> Maybe Int
-cipherTagSize (CBC bc _)       = Nothing
-cipherTagSize (CFB bc _)       = Nothing
-cipherTagSize (XTS bc)         = Nothing
-cipherTagSize chaCha20Poly1305 = Just 16
-cipherTagSize (GCM _ tsz)      = Just tsz
-cipherTagSize (OCB _ tsz)      = Just tsz
-cipherTagSize (EAX _ tsz)      = Just tsz
-cipherTagSize (SIV _)          = Just 16
-cipherTagSize (CCM _ tsz _)    = Just tsz
+cipherTagSize (CBC _bc _)       = Nothing
+cipherTagSize (CFB _bc _)       = Nothing
+cipherTagSize (XTS _bc)         = Nothing
+cipherTagSize _chaCha20Poly1305 = Just 16
+cipherTagSize (GCM _ tsz)       = Just tsz
+cipherTagSize (OCB _ tsz)       = Just tsz
+cipherTagSize (EAX _ tsz)       = Just tsz
+cipherTagSize (SIV _)           = Just 16
+cipherTagSize (CCM _ tsz _)     = Just tsz
 -- NOTE: Extracted / confirmed from inspecting:
 {-
 generateCipherTagLength :: IO ()
@@ -432,9 +412,6 @@ generateCipherTagLength = do
         "cipherTagLength :: Cipher -> Int"
         : each
 -}
-
-aeadTagSize :: AEAD -> Int
-aeadTagSize = fromJust . cipherTagSize .  unAEAD
 
 cipherUpdateGranularity :: Cipher -> Int
 cipherUpdateGranularity (CBC bc CTS)        = 2 * blockCipherBlockSize bc
@@ -553,7 +530,7 @@ destroyCipher = liftIO . Low.cipherDestroy . mutableCipherCtx
 data CipherDirection
     = CipherEncrypt
     | CipherDecrypt
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 cipherDirectionFlags :: CipherDirection -> Low.CipherInitFlags
 cipherDirectionFlags CipherEncrypt = Low.Encrypt
@@ -563,7 +540,7 @@ cipherDirectionFlags CipherDecrypt = Low.Decrypt
 data CipherUpdate
     = CipherUpdate
     | CipherFinal
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
 
 cipherUpdateFlags :: CipherUpdate -> Low.CipherUpdateFlags
 cipherUpdateFlags CipherUpdate = Low.CipherUpdate

--- a/botan/src/Botan/Cipher/ChaCha20Poly1305.hs
+++ b/botan/src/Botan/Cipher/ChaCha20Poly1305.hs
@@ -1,21 +1,20 @@
-module Botan.Cipher.ChaCha20Poly1305
-( ChaCha20Poly1305(..)
-, ChaCha20Poly1305SecretKey(..)
-, ChaCha20Poly1305Nonce(..)
-, ChaCha20Poly1305Ciphertext(..)
-, ChaCha20Poly1305LazyCiphertext(..)
-, chaCha20Poly1305Encrypt
-, chaCha20Poly1305Decrypt
-, chaCha20Poly1305EncryptLazy
-, chaCha20Poly1305DecryptLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Cipher.ChaCha20Poly1305 (
+    ChaCha20Poly1305
+  , ChaCha20Poly1305SecretKey
+  , ChaCha20Poly1305Nonce
+  , ChaCha20Poly1305Ciphertext
+  , ChaCha20Poly1305LazyCiphertext
+  , chaCha20Poly1305Encrypt
+  , chaCha20Poly1305Decrypt
+  , chaCha20Poly1305EncryptLazy
+  , chaCha20Poly1305DecryptLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.Cipher as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -31,44 +30,36 @@ data ChaCha20Poly1305
 newtype instance SecretKey ChaCha20Poly1305 = MkChaCha20Poly1305SecretKey GSecretKey
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ChaCha20Poly1305SecretKey #-}
 pattern ChaCha20Poly1305SecretKey :: ByteString -> SecretKey ChaCha20Poly1305
 pattern ChaCha20Poly1305SecretKey bytes = MkChaCha20Poly1305SecretKey (MkGSecretKey bytes)
-
-getChaCha20Poly1305SecretKey :: SecretKey ChaCha20Poly1305 -> ByteString
-getChaCha20Poly1305SecretKey (ChaCha20Poly1305SecretKey bs) = bs
 
 type ChaCha20Poly1305SecretKey = SecretKey ChaCha20Poly1305
 
 newtype instance Nonce ChaCha20Poly1305 = MkChaCha20Poly1305Nonce GNonce
     deriving newtype (Eq, Ord, Show, Encodable, IsNonce)
 
+{-# COMPLETE ChaCha20Poly1305Nonce #-}
 pattern ChaCha20Poly1305Nonce :: ByteString -> Nonce ChaCha20Poly1305
 pattern ChaCha20Poly1305Nonce bytes = MkChaCha20Poly1305Nonce (MkGNonce bytes)
-
-getChaCha20Poly1305Nonce :: Nonce ChaCha20Poly1305 -> ByteString
-getChaCha20Poly1305Nonce (ChaCha20Poly1305Nonce bs) = bs
 
 type ChaCha20Poly1305Nonce = Nonce ChaCha20Poly1305
 
 newtype instance Ciphertext ChaCha20Poly1305 = MkChaCha20Poly1305Ciphertext GCiphertext
     deriving newtype (Eq, Ord, Show, Encodable)
 
+{-# COMPLETE ChaCha20Poly1305Ciphertext #-}
 pattern ChaCha20Poly1305Ciphertext :: ByteString -> Ciphertext ChaCha20Poly1305
 pattern ChaCha20Poly1305Ciphertext bs = MkChaCha20Poly1305Ciphertext (MkGCiphertext bs)
-
-getChaCha20Poly1305Ciphertext :: Ciphertext ChaCha20Poly1305 -> ByteString
-getChaCha20Poly1305Ciphertext (ChaCha20Poly1305Ciphertext bs) = bs
 
 type ChaCha20Poly1305Ciphertext = Ciphertext ChaCha20Poly1305
 
 newtype instance LazyCiphertext ChaCha20Poly1305 = MkChaCha20Poly1305LazyCiphertext GLazyCiphertext
     deriving newtype (Eq, Ord, Show, Encodable, LazyEncodable)
 
+{-# COMPLETE ChaCha20Poly1305LazyCiphertext #-}
 pattern ChaCha20Poly1305LazyCiphertext :: Lazy.ByteString -> LazyCiphertext ChaCha20Poly1305
 pattern ChaCha20Poly1305LazyCiphertext lbs = MkChaCha20Poly1305LazyCiphertext (MkGLazyCiphertext lbs)
-
-getChaCha20Poly1305LazyCiphertext :: LazyCiphertext ChaCha20Poly1305 -> Lazy.ByteString
-getChaCha20Poly1305LazyCiphertext (ChaCha20Poly1305LazyCiphertext bs) = bs
 
 type ChaCha20Poly1305LazyCiphertext = LazyCiphertext ChaCha20Poly1305
 
@@ -77,12 +68,12 @@ instance HasSecretKey ChaCha20Poly1305 where
     secretKeySpec :: SizeSpecifier (SecretKey ChaCha20Poly1305)
     secretKeySpec = coerceSizeSpec $ Botan.cipherKeySpec Botan.chaCha20Poly1305
 
-instance (MonadRandomIO m )=> SecretKeyGen ChaCha20Poly1305 m where
+instance MonadRandomIO m => SecretKeyGen ChaCha20Poly1305 m where
 
-    newSecretKey :: MonadRandomIO m => m (SecretKey ChaCha20Poly1305)
+    newSecretKey :: m (SecretKey ChaCha20Poly1305)
     newSecretKey = ChaCha20Poly1305SecretKey <$> newSized (secretKeySpec @ChaCha20Poly1305)
 
-    newSecretKeyMaybe :: MonadRandomIO m => Int -> m (Maybe (SecretKey ChaCha20Poly1305))
+    newSecretKeyMaybe :: Int -> m (Maybe (SecretKey ChaCha20Poly1305))
     newSecretKeyMaybe i = fmap ChaCha20Poly1305SecretKey <$> newSizedMaybe (secretKeySpec @ChaCha20Poly1305) i
 
 instance HasNonce ChaCha20Poly1305 where
@@ -93,12 +84,12 @@ instance HasNonce ChaCha20Poly1305 where
     -- We should be moving algo-specific stuff here anyway.
     nonceSpec = SizeEnum [ 8, 12, 24 ]
 
-instance (MonadRandomIO m )=> NonceGen ChaCha20Poly1305 m where
+instance MonadRandomIO m => NonceGen ChaCha20Poly1305 m where
 
-    newNonce :: MonadRandomIO m => m (Nonce ChaCha20Poly1305)
+    newNonce :: m (Nonce ChaCha20Poly1305)
     newNonce = ChaCha20Poly1305Nonce <$> newSized (nonceSpec @ChaCha20Poly1305)
 
-    newNonceMaybe :: MonadRandomIO m => Int -> m (Maybe (Nonce ChaCha20Poly1305))
+    newNonceMaybe :: Int -> m (Maybe (Nonce ChaCha20Poly1305))
     newNonceMaybe i = fmap ChaCha20Poly1305Nonce <$> newSizedMaybe (nonceSpec @ChaCha20Poly1305) i
 
 instance HasCiphertext ChaCha20Poly1305 where

--- a/botan/src/Botan/Cipher/Class.hs
+++ b/botan/src/Botan/Cipher/Class.hs
@@ -1,19 +1,21 @@
-module Botan.Cipher.Class
-( Cipher(..)
-, SecretKey(..)
-, Nonce(..)
-, Ciphertext(..)
-, LazyCiphertext(..)
-, cipherEncryptProxy
-, cipherDecryptProxy
-, cipherEncryptFile
-, cipherDecryptFile
-, IncrementalCipher(..)
-, cipherEncryptFileLazy
-, cipherDecryptFileLazy
--- , MutableCipher(..)
--- , MutableCtx(..)
-) where
+{-# LANGUAGE DefaultSignatures #-}
+
+module Botan.Cipher.Class (
+    Cipher(..)
+  , SecretKey
+  , Nonce
+  , Ciphertext
+  , LazyCiphertext
+  , cipherEncryptProxy
+  , cipherDecryptProxy
+  , cipherEncryptFile
+  , cipherDecryptFile
+  , IncrementalCipher(..)
+  , cipherEncryptFileLazy
+  , cipherDecryptFileLazy
+  -- , MutableCipher(..)
+  -- , MutableCtx(..)
+  ) where
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
 
@@ -22,7 +24,6 @@ import           Data.Proxy (Proxy (..))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 
-import           Botan.RNG
 import           Botan.Types.Class
 
 -- NOTE: I think that CBC NoPadding is the only cipher that doesn't accept arbitrary length input
@@ -49,7 +50,7 @@ cipherEncryptFile k n fp = cipherEncrypt k n <$> liftIO (ByteString.readFile fp)
 cipherDecryptFile :: (Cipher c, MonadIO m) => SecretKey c -> Nonce c -> FilePath -> m (Maybe ByteString)
 cipherDecryptFile k n fp = cipherDecrypt k n . unsafeDecode <$> liftIO (ByteString.readFile fp)
 
-class (Cipher c, HasLazyCiphertext c) => IncrementalCipher c where
+class HasLazyCiphertext c => IncrementalCipher c where
 
     cipherEncryptLazy :: SecretKey c -> Nonce c -> Lazy.ByteString -> LazyCiphertext c
     cipherDecryptLazy :: SecretKey c -> Nonce c -> LazyCiphertext c -> Maybe Lazy.ByteString

--- a/botan/src/Botan/Easy.hs
+++ b/botan/src/Botan/Easy.hs
@@ -1,24 +1,22 @@
-module Botan.Easy
-( Digest(..)
-, hash
-, verifyDigest
-, BlockCipherKey(..)
-, BlockCiphertext(..)
-, newBlockCipherKey
-, blockCipherEncrypt
-, blockCipherDecrypt
-, CipherKey(..)
-, CipherNonce(..)
-, Ciphertext(..)
-, newCipherKey
-, newCipherNonce
-, cipherEncrypt
-, cipherDecrypt
-) where
+module Botan.Easy (
+    Digest
+  , hash
+  , verifyDigest
+  , BlockCipherKey
+  , BlockCiphertext
+  , newBlockCipherKey
+  , blockCipherEncrypt
+  , blockCipherDecrypt
+  , CipherKey
+  , CipherNonce
+  , Ciphertext
+  , newCipherKey
+  , newCipherNonce
+  , cipherEncrypt
+  , cipherDecrypt
+  ) where
 
 import           Botan.Prelude hiding (Ciphertext, LazyCiphertext)
-
-import           Data.ByteString (ByteString)
 
 import           Botan.RNG (MonadRandomIO (..))
 

--- a/botan/src/Botan/Error.hs
+++ b/botan/src/Botan/Error.hs
@@ -1,8 +1,6 @@
-module Botan.Error
-( module Botan.Low.Error
-) where
-
-import           Botan.Prelude
+module Botan.Error (
+    module Botan.Low.Error
+  ) where
 
 import           Botan.Low.Error hiding (catchBotan, handleBotan, tryBotan)
 

--- a/botan/src/Botan/HOTP.hs
+++ b/botan/src/Botan/HOTP.hs
@@ -1,6 +1,19 @@
-module Botan.HOTP where
-
-import qualified Data.ByteString as ByteString
+module Botan.HOTP (
+    MutableHOTP
+  , HOTP (..)
+  , hotpHash
+  , hotpAlgo
+  , HOTPKey
+  , HOTPCtx (..)
+  , HOTPLength (..)
+  , hotpLength
+  , newHOTP
+  , hotpGenerate
+  , hotpCheck
+  , hotpCtxInit
+  , hotpCtxGenerate
+  , hotpCtxCheck
+  ) where
 
 import qualified Botan.Low.HOTP as Low
 
@@ -63,10 +76,10 @@ hotpCheck = undefined
 
 -- NOTE: Digits should be 6-8
 hotpCtxInit :: ByteString -> ByteString -> Int -> IO HOTPCtx
-hotpCtxInit key algo digits = undefined
+hotpCtxInit _key _algo _digits = undefined
 
 hotpCtxGenerate :: HOTPCtx -> Low.HOTPCounter -> (Low.HOTPCode, HOTPCtx)
-hotpCtxGenerate hotp counter = undefined
+hotpCtxGenerate _hotp _counter = undefined
 
 -- NOTE:
 --      "Returns a pair of (is_valid,next_counter_to_use). If the OTP is
@@ -74,4 +87,4 @@ hotpCtxGenerate hotp counter = undefined
 --      last successful authentication counter has not changed. "
 -- NOTE: "Depending on the environment a resync_range of 3 to 10 might be appropriate."
 hotpCtxCheck :: HOTPCtx -> Low.HOTPCode -> Low.HOTPCounter -> Int -> (Bool, Low.HOTPCounter)
-hotpCtxCheck hotp code counter resync = undefined
+hotpCtxCheck _hotp _code _counter _resync = undefined

--- a/botan/src/Botan/Hash/BLAKE.hs
+++ b/botan/src/Botan/Hash/BLAKE.hs
@@ -1,16 +1,18 @@
-module Botan.Hash.BLAKE
-( BLAKE2b(..)
-, BLAKE2bDigest(..)
-, blake2b
-, blake2bLazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.BLAKE (
+    BLAKE2b
+  , BLAKE2bDigest
+  , blake2b
+  , blake2bLazy
+  ) where
 
 import           GHC.TypeLits
 
 import           Data.Maybe
 import           Data.Proxy
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -29,7 +31,7 @@ type BLAKE2bSize (n :: Nat) = (KnownNat n, (1 <=? n) ~ True, Mod n 8 ~ 0, (n <=?
 type BLAKE2bDigest n = Digest (BLAKE2b n)
 
 newtype instance Digest (BLAKE2b n) = BLAKE2bDigest
-    { getBLAKE2bByteString :: ByteString {- ByteVector n -} }
+    { _getBLAKE2bByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (BLAKE2b n)) where

--- a/botan/src/Botan/Hash/Class.hs
+++ b/botan/src/Botan/Hash/Class.hs
@@ -1,13 +1,14 @@
-module Botan.Hash.Class
-( Hash(..)
-, Digest(..)
-, hashProxy
-, hashFile
-, IncrementalHash(..)
-, hashFileLazy
--- , MutableHash(..)
--- , MutableCtx(..)
-) where
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Botan.Hash.Class (
+    Hash(..)
+  , Digest
+  , hashProxy
+  , hashFile
+  , IncrementalHash(..)
+  , hashFileLazy
+  ) where
 
 import           Botan.Prelude
 
@@ -32,7 +33,7 @@ hashProxy _ = hash
 hashFile :: (Hash hash, MonadIO m) => FilePath -> m (Digest hash)
 hashFile fp = hash <$> liftIO (ByteString.readFile fp)
 
-class (Hash hash) => IncrementalHash hash where
+class IncrementalHash hash where
     hashLazy :: Lazy.ByteString -> Digest hash
 
 hashFileLazy :: (IncrementalHash hash, MonadIO m) => FilePath -> m (Digest hash)
@@ -42,44 +43,3 @@ hashFileLazy fp = do
     let d = hashLazy bs
         in d `seq` return d
 
--- Experimental below
-
-
--- TODO: Mutable hashes
-
--- TODO: Rename Mutable?
-data family MutableCtx hash
-
-class (IncrementalHash hash, MonadIO m) => MutableHash hash m where
-    hashInit     :: m (MutableCtx hash)
-    hashUpdate   :: MutableCtx hash -> ByteString -> m ()
-    hashUpdates  :: MutableCtx hash -> [ByteString] -> m ()
-    hashFinalize :: MutableCtx hash -> m (Digest hash)
-
-
-mutableHashLazy :: MutableHash hash m => Lazy.ByteString -> m (Digest hash)
-mutableHashLazy lbs = do
-    ctx <- hashInit
-    hashUpdates ctx $ Lazy.toChunks lbs
-    hashFinalize ctx
-
-
-
--- TODO: Something like `Salted "salt" SHA3_512` for static salts?
-{-
-
-data Salted (salt :: Symbol) h
-
--- NOTE: Needs proper encodable to get rid of coerce
-instance (KnownSymbol salt, Hash h) => Hash (Salted salt h) where
-    hash bs = SaltedDigest $ unsafeCoerce $ hash @h $ bs <> Char8.pack (symbolVal (Proxy @salt))
-
-newtype instance Digest (Salted salt h) = SaltedDigest
-    { getSaltedByteString :: ByteString {- ByteVector n -} }
-    deriving newtype (Eq, Ord)
-
-instance (KnownSymbol salt, Hash h) => Show (Digest (Salted salt h)) where
-    show :: Digest (Salted salt h) -> String
-    show (SaltedDigest bytes) = Text.unpack $ Botan.hexEncode bytes Botan.Lower
-
--}

--- a/botan/src/Botan/Hash/GOST.hs
+++ b/botan/src/Botan/Hash/GOST.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.GOST
-( GOST_34_11(..)
-, GOST_34_11Digest(..)
-, gost_34_11
-, gost_34_11Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.GOST (
+    GOST_34_11
+  , GOST_34_11Digest
+  , gost_34_11
+  , gost_34_11Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data GOST_34_11
 
 newtype instance Digest GOST_34_11 = GOST_34_11Digest
-    { getGOST_34_11ByteString :: ByteString {- ByteVector n -} }
+    { _getGOST_34_11ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type GOST_34_11Digest = Digest GOST_34_11

--- a/botan/src/Botan/Hash/Keccak.hs
+++ b/botan/src/Botan/Hash/Keccak.hs
@@ -1,9 +1,12 @@
-module Botan.Hash.Keccak
-( Keccak1600(..)
-, Keccak1600Digest(..)
-, keccak1600
-, keccak1600Lazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.Keccak (
+    Keccak1600
+  , Keccak1600Digest
+  , keccak1600
+  , keccak1600Lazy
+  ) where
 
 import           GHC.TypeLits
 
@@ -13,7 +16,6 @@ import           Data.Proxy
 import           Data.Type.Bool
 import           Data.Type.Equality
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -32,7 +34,7 @@ type Keccak1600Size (n :: Nat) = (KnownNat n, (n == 224 || n == 256 || n == 384 
 type Keccak1600Digest n = Digest (Keccak1600 n)
 
 newtype instance Digest (Keccak1600 n) = Keccak1600Digest
-    { getKeccak1600ByteString :: ByteString {- ByteVector n -} }
+    { _getKeccak1600ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (Keccak1600 n)) where

--- a/botan/src/Botan/Hash/MD4.hs
+++ b/botan/src/Botan/Hash/MD4.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.MD4
-( MD4(..)
-, MD4Digest(..)
-, md4
-, md4Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.MD4 (
+    MD4
+  , MD4Digest
+  , md4
+  , md4Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data MD4
 
 newtype instance Digest MD4 = MD4Digest
-    { getMD4ByteString :: ByteString {- ByteVector n -} }
+    { _getMD4ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type MD4Digest = Digest MD4

--- a/botan/src/Botan/Hash/MD5.hs
+++ b/botan/src/Botan/Hash/MD5.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.MD5
-( MD5(..)
-, MD5Digest(..)
-, md5
-, md5Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.MD5 (
+    MD5
+  , MD5Digest
+  , md5
+  , md5Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data MD5
 
 newtype instance Digest MD5 = MD5Digest
-    { getMD5ByteString :: ByteString {- ByteVector n -} }
+    { _getMD5ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type MD5Digest = Digest MD5
@@ -44,25 +45,3 @@ md5 = hash
 
 md5Lazy :: Lazy.ByteString -> MD5Digest
 md5Lazy = hashLazy
-
--- Experimental below
-
--- newtype instance MutableCtx MD5 = MD5Ctx
---     { getMD5Ctx :: Botan.MutableHash }
-
--- -- TODO: Rename MutableMD5?
--- type MD5Ctx = MutableCtx MD5
-
--- instance (MonadIO m) => MutableHash MD5 m where
-
---     hashInit :: m MD5Ctx
---     hashInit = MD5Ctx <$> Botan.newHash Botan.md5
-
---     hashUpdate :: MD5Ctx -> ByteString -> m ()
---     hashUpdate (MD5Ctx ctx) = Botan.updateHash ctx
-
---     hashUpdates :: MD5Ctx -> [ByteString] -> m ()
---     hashUpdates (MD5Ctx ctx) = Botan.updateHashChunks ctx
-
---     hashFinalize :: MD5Ctx -> m (Digest MD5)
---     hashFinalize (MD5Ctx ctx) = MD5Digest <$> Botan.finalizeHash ctx

--- a/botan/src/Botan/Hash/RIPEMD.hs
+++ b/botan/src/Botan/Hash/RIPEMD.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.RIPEMD
-( RIPEMD160(..)
-, RIPEMD160Digest(..)
-, ripemd160
-, ripemd160Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.RIPEMD (
+    RIPEMD160
+  , RIPEMD160Digest
+  , ripemd160
+  , ripemd160Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data RIPEMD160
 
 newtype instance Digest RIPEMD160 = RIPEMD160Digest
-    { getRIPEMD160ByteString :: ByteString {- ByteVector n -} }
+    { _getRIPEMD160ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type RIPEMD160Digest = Digest RIPEMD160

--- a/botan/src/Botan/Hash/SHA1.hs
+++ b/botan/src/Botan/Hash/SHA1.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.SHA1
-( SHA1(..)
-, SHA1Digest(..)
-, sha1
-, sha1Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.SHA1 (
+    SHA1
+  , SHA1Digest
+  , sha1
+  , sha1Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data SHA1
 
 newtype instance Digest SHA1 = SHA1Digest
-    { getSHA1ByteString :: ByteString {- ByteVector n -} }
+    { _getSHA1ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type SHA1Digest = Digest SHA1

--- a/botan/src/Botan/Hash/SHA2.hs
+++ b/botan/src/Botan/Hash/SHA2.hs
@@ -1,13 +1,16 @@
-module Botan.Hash.SHA2
-( SHA2(..)
-, SHA2Digest(..)
-, sha2
-, sha2Lazy
-, SHA2_512_256(..)
-, SHA2_512_256Digest(..)
-, sha2_512_256
-, sha2_512_256Lazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.SHA2 (
+    SHA2
+  , SHA2Digest
+  , sha2
+  , sha2Lazy
+  , SHA2_512_256
+  , SHA2_512_256Digest
+  , sha2_512_256
+  , sha2_512_256Lazy
+  ) where
 
 import           GHC.TypeLits
 
@@ -17,7 +20,6 @@ import           Data.Proxy
 import           Data.Type.Bool
 import           Data.Type.Equality
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -36,7 +38,7 @@ type SHA2Size (n :: Nat) = (KnownNat n, (n == 224 || n == 256 || n == 384 || n =
 type SHA2Digest n = Digest (SHA2 n)
 
 newtype instance Digest (SHA2 n) = SHA2Digest
-    { getSHA2ByteString :: ByteString {- ByteVector n -} }
+    { _getSHA2ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (SHA2 n)) where
@@ -68,7 +70,7 @@ sha2Lazy = hashLazy
 data SHA2_512_256
 
 newtype instance Digest SHA2_512_256 = SHA2_512_256Digest
-    { getSHA2_512_256ByteString :: ByteString {- ByteVector n -} }
+    { _getSHA2_512_256ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type SHA2_512_256Digest = Digest SHA2_512_256

--- a/botan/src/Botan/Hash/SHA3.hs
+++ b/botan/src/Botan/Hash/SHA3.hs
@@ -1,26 +1,29 @@
-module Botan.Hash.SHA3
-( SHA3(..)
-, SHA3Size(..)
-, SHA3Digest(..)
-, sha3
-, sha3Lazy
-, SHA3_224(..)
-, SHA3_224Digest(..)
-, sha3_224
-, sha3_224Lazy
-, SHA3_256(..)
-, SHA3_256Digest(..)
-, sha3_256
-, sha3_256Lazy
-, SHA3_384(..)
-, SHA3_384Digest(..)
-, sha3_384
-, sha3_384Lazy
-, SHA3_512(..)
-, SHA3_512Digest(..)
-, sha3_512
-, sha3_512Lazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.SHA3 (
+    SHA3
+  , SHA3Size
+  , SHA3Digest
+  , sha3
+  , sha3Lazy
+  , SHA3_224
+  , SHA3_224Digest
+  , sha3_224
+  , sha3_224Lazy
+  , SHA3_256
+  , SHA3_256Digest
+  , sha3_256
+  , sha3_256Lazy
+  , SHA3_384
+  , SHA3_384Digest
+  , sha3_384
+  , sha3_384Lazy
+  , SHA3_512
+  , SHA3_512Digest
+  , sha3_512
+  , sha3_512Lazy
+  ) where
 
 import           GHC.TypeLits
 
@@ -30,7 +33,6 @@ import           Data.Proxy
 import           Data.Type.Bool
 import           Data.Type.Equality
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -50,7 +52,7 @@ type SHA3Size (n :: Nat) = (KnownNat n, (n == 224 || n == 256 || n == 384 || n =
 type SHA3Digest n = Digest (SHA3 n)
 
 newtype instance Digest (SHA3 n) = SHA3Digest
-    { getSHA3ByteString :: ByteString {- ByteVector n -} }
+    { _getSHA3ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (SHA3 n)) where

--- a/botan/src/Botan/Hash/SHAKE.hs
+++ b/botan/src/Botan/Hash/SHAKE.hs
@@ -1,20 +1,22 @@
-module Botan.Hash.SHAKE
-( SHAKE128(..)
-, SHAKE128Digest(..)
-, shake128
-, shake128Lazy
-, SHAKE256(..)
-, SHAKE256Digest(..)
-, shake256
-, shake256Lazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.SHAKE (
+    SHAKE128
+  , SHAKE128Digest
+  , shake128
+  , shake128Lazy
+  , SHAKE256
+  , SHAKE256Digest
+  , shake256
+  , shake256Lazy
+  ) where
 
 import           GHC.TypeLits
 
 import           Data.Maybe
 import           Data.Proxy
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -33,7 +35,7 @@ type SHAKE128Size (n :: Nat) = (KnownNat n, (1 <=? n) ~ True, Mod n 8 ~ 0, (n <=
 type SHAKE128Digest n = Digest (SHAKE128 n)
 
 newtype instance Digest (SHAKE128 n) = SHAKE128Digest
-    { getSHAKE128ByteString :: ByteString {- ByteVector n -} }
+    { _getSHAKE128ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (SHAKE128 n)) where
@@ -69,7 +71,7 @@ type SHAKE256Size (n :: Nat) = (KnownNat n, (1 <=? n) ~ True, Mod n 8 ~ 0, (n <=
 type SHAKE256Digest n = Digest (SHAKE256 n)
 
 newtype instance Digest (SHAKE256 n) = SHAKE256Digest
-    { getSHAKE256ByteString :: ByteString {- ByteVector n -} }
+    { _getSHAKE256ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (SHAKE256 n)) where

--- a/botan/src/Botan/Hash/SM3.hs
+++ b/botan/src/Botan/Hash/SM3.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.SM3
-( SM3(..)
-, SM3Digest(..)
-, sm3
-, sm3Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.SM3 (
+    SM3
+  , SM3Digest
+  , sm3
+  , sm3Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data SM3
 
 newtype instance Digest SM3 = SM3Digest
-    { getSM3ByteString :: ByteString {- ByteVector n -} }
+    { _getSM3ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type SM3Digest = Digest SM3

--- a/botan/src/Botan/Hash/Skein.hs
+++ b/botan/src/Botan/Hash/Skein.hs
@@ -1,18 +1,20 @@
-module Botan.Hash.Skein
-( Skein512(..)
-, Skein512Digest(..)
-, Skein512'(..)
-, Skein512Digest'(..)
-, skein512
-, skein512Lazy
-) where
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.Hash.Skein (
+    Skein512
+  , Skein512Digest
+  , Skein512'
+  , Skein512Digest'
+  , skein512
+  , skein512Lazy
+  ) where
 
 import           GHC.TypeLits
 
 import           Data.Maybe
 import           Data.Proxy
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
@@ -35,7 +37,7 @@ type SkeinSize (n :: Nat) = (KnownNat n, (1 <=? n) ~ True, Mod n 8 ~ 0, (n <=? 5
 type SkeinPersonalizationString (ps :: Symbol) = (KnownSymbol ps)
 
 newtype instance Digest (Skein512' n ps) = SkeinDigest
-    { getSkeinByteString :: ByteString {- ByteVector n -} }
+    { _getSkeinByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (Digest (Skein512' n ps)) where

--- a/botan/src/Botan/Hash/Streebog.hs
+++ b/botan/src/Botan/Hash/Streebog.hs
@@ -1,15 +1,16 @@
-module Botan.Hash.Streebog
-( Streebog256(..)
-, Streebog256Digest(..)
-, streebog256
-, streebog256Lazy
-, Streebog512(..)
-, Streebog512Digest(..)
-, streebog512
-, streebog512Lazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.Streebog (
+    Streebog256
+  , Streebog256Digest
+  , streebog256
+  , streebog256Lazy
+  , Streebog512
+  , Streebog512Digest
+  , streebog512
+  , streebog512Lazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -24,7 +25,7 @@ import           Botan.Prelude
 data Streebog256
 
 newtype instance Digest Streebog256 = Streebog256Digest
-    { getStreebog256ByteString :: ByteString {- ByteVector n -} }
+    { _getStreebog256ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type Streebog256Digest = Digest Streebog256
@@ -54,7 +55,7 @@ streebog256Lazy = hashLazy
 data Streebog512
 
 newtype instance Digest Streebog512 = Streebog512Digest
-    { getStreebog512ByteString :: ByteString {- ByteVector n -} }
+    { _getStreebog512ByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type Streebog512Digest = Digest Streebog512

--- a/botan/src/Botan/Hash/Whirlpool.hs
+++ b/botan/src/Botan/Hash/Whirlpool.hs
@@ -1,11 +1,12 @@
-module Botan.Hash.Whirlpool
-( Whirlpool(..)
-, WhirlpoolDigest(..)
-, whirlpool
-, whirlpoolLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
 
-import qualified Data.ByteString as ByteString
+module Botan.Hash.Whirlpool (
+    Whirlpool
+  , WhirlpoolDigest
+  , whirlpool
+  , whirlpoolLazy
+  ) where
+
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -20,7 +21,7 @@ import           Botan.Prelude
 data Whirlpool
 
 newtype instance Digest Whirlpool = WhirlpoolDigest
-    { getWhirlpoolByteString :: ByteString {- ByteVector n -} }
+    { _getWhirlpoolByteString :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type WhirlpoolDigest = Digest Whirlpool

--- a/botan/src/Botan/KDF.hs
+++ b/botan/src/Botan/KDF.hs
@@ -1,10 +1,14 @@
-module Botan.KDF where
+module Botan.KDF (
+    KDF (..)
+  , SP800_108_Mode (..)
+  , kdfName
+  , kdf
+  ) where
 
-import           Botan.Low.KDF (KDFName (..))
+import           Botan.Low.KDF (KDFName)
 import qualified Botan.Low.KDF as Low
 
 import           Botan.Hash
-import           Botan.MAC
 import           Botan.Prelude
 
 -- Sources: https://github.com/randombit/botan/blob/master/src/lib/kdf/kdf.cpp
@@ -42,7 +46,7 @@ data KDF
     | SP800_108_Pipeline Hash
     | SP800_56A Hash
     | SP800_56C Hash
-    deriving (Show, Eq)
+    deriving stock (Show, Eq)
 
 -- TODO: | SP800_108 SP800_108_Mode MAC
 

--- a/botan/src/Botan/KeySpec.hs
+++ b/botan/src/Botan/KeySpec.hs
@@ -1,4 +1,15 @@
-module Botan.KeySpec where
+module Botan.KeySpec (
+    KeySpec
+  , keySpec
+  , monoMapKeySpec
+  , minKeySize
+  , maxKeySize
+  , keySizes
+  , validKeySize
+  , keySizeIsValid
+  , newKeyMaybe
+  , newKey
+  ) where
 
 import           Botan.Prelude
 

--- a/botan/src/Botan/KeyWrap.hs
+++ b/botan/src/Botan/KeyWrap.hs
@@ -1,4 +1,15 @@
-module Botan.KeyWrap where
+module Botan.KeyWrap (
+    KWKey
+  , KWPKey
+  , KWWrappedKey
+  , KWPWrappedKey
+  , keyWrap
+  , keyUnwrap
+  , keyWrapPadded
+  , keyUnwrapPadded
+  , nistKeyWrapEncode
+  , nistKeyWrapDecode
+  ) where
 
 import qualified Botan.Low.KeyWrap as Low
 

--- a/botan/src/Botan/MAC.hs
+++ b/botan/src/Botan/MAC.hs
@@ -36,82 +36,81 @@ The Botan MAC computation is split into five stages.
 
 -}
 
-module Botan.MAC
-(
+module Botan.MAC (
 
--- * Message Authentication Codes
--- $introduction
+  -- * Message Authentication Codes
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Idiomatic interface
+  -- * Idiomatic interface
 
--- ** Data type
-  MAC(..)
+  -- ** Data type
+    MAC(..)
 
--- ** Enumerations
+  -- ** Enumerations
 
-, macs
+  , macs
 
--- ** Associated types
-, MACKeySpec
-, MACKey(..)
-, newMACKey
-, newMACKeyMaybe
-, MACDigest(..)
+  -- ** Associated types
+  , MACKeySpec
+  , MACKey
+  , newMACKey
+  , newMACKeyMaybe
+  , MACDigest
 
--- ** Accessors
+  -- ** Accessors
 
-, macName
-, macKeySpec
-, macDigestLength
+  , macName
+  , macKeySpec
+  , macDigestLength
 
--- ** Idiomatic algorithm
-, mac
-, gmac
+  -- ** Idiomatic algorithm
+  , mac
+  , gmac
 
-, macLazy
+  , macLazy
 
--- * Mutable interface
+  -- * Mutable interface
 
--- ** Tagged mutable context
-, MutableMAC(..)
+  -- ** Tagged mutable context
+  , MutableMAC(..)
 
--- ** Destructor
-, destroyMAC
+  -- ** Destructor
+  , destroyMAC
 
--- ** Initializers
-, newMAC
+  -- ** Initializers
+  , newMAC
 
--- ** Accessors
-, getMACName
-, getMACKeySpec
-, getMACDigestLength
-, setMACKey
+  -- ** Accessors
+  , getMACName
+  , getMACKeySpec
+  , getMACDigestLength
+  , setMACKey
 
--- ** GMAC-specific functions
-, GMACNonce(..)
-, setGMACNonce
+  -- ** GMAC-specific functions
+  , GMACNonce
+  , setGMACNonce
 
--- ** Accessory functions
-, clearMAC
+  -- ** Accessory functions
+  , clearMAC
 
--- ** Mutable algorithm
-, updateMAC
-, finalizeMAC
-, updateFinalizeMAC
-, updateFinalizeClearMAC
+  -- ** Mutable algorithm
+  , updateMAC
+  , finalizeMAC
+  , updateFinalizeMAC
+  , updateFinalizeClearMAC
 
--- *Algorithm references
-, cmac
-, hmac
--- , kmac
-, poly1305
-, sipHash
-, x9_19_mac
+  -- *Algorithm references
+  , cmac
+  , hmac
+  -- , kmac
+  , poly1305
+  , sipHash
+  , x9_19_mac
 
-) where
+  ) where
 
 import           Data.Foldable
 
@@ -120,9 +119,7 @@ import qualified Data.ByteString.Lazy as Lazy
 
 import qualified Botan.Low.MAC as Low
 
-import qualified Botan.Bindings.MAC as Low
 import           Botan.BlockCipher
-import           Botan.Error (SomeBotanException (SomeBotanException))
 import           Botan.Hash
 import           Botan.KeySpec
 import           Botan.Prelude
@@ -161,10 +158,11 @@ data MAC
     | Poly1305              -- Requires a unique key per message (key r and nonce s have been combined)
     | SipHash Int Int       -- Number of input and finalization rounds
     | X9_19_MAC
-    deriving (Eq, Show)
+    deriving stock (Eq, Show)
 
 -- Enumerations
 
+macs :: [MAC]
 macs = concat
     [ [ CMAC bc | bc <- blockCiphers ]
     , [ GMAC bc | bc <- blockCiphers ] -- Requires a nonce
@@ -203,10 +201,11 @@ macName X9_19_MAC       = Low.X9_19_MAC
 macKeySpec :: MAC -> KeySpec
 macKeySpec (CMAC bc)     = blockCipherKeySpec bc
 macKeySpec (GMAC bc)     = blockCipherKeySpec bc
-macKeySpec (HMAC h)      = keySpec 0 4096 1
+macKeySpec (HMAC _h)     = keySpec 0 4096 1
 macKeySpec Poly1305      = keySpec 32 32 1
 macKeySpec (SipHash 2 4) = keySpec 16 16 1
 macKeySpec X9_19_MAC     = keySpec 8 16 8
+macKeySpec _             = error "macKeySpec"
 -- NOTE: Extracted from inspecting:
 {-
 generateMACKeySpec :: IO ()
@@ -238,6 +237,7 @@ macDigestLength Poly1305      = 16
 -- TODO: Check more variants
 macDigestLength (SipHash 2 4) = 8
 macDigestLength X9_19_MAC     = 8
+macDigestLength _             = error "macDigestLength"
 -- NOTE: Extracted / confirmed from inspecting:
 {-
 generateMACDigestSize :: IO ()
@@ -363,8 +363,8 @@ setGMACNonce
     => GMACNonce
     -> MutableMAC
     -> m ()
-setGMACNonce n mm@(MkMutableMAC (GMAC _) ctx) = liftIO $ Low.macSetNonce ctx n
-setGMACNonce _ _                              = return ()
+setGMACNonce n _mm@(MkMutableMAC (GMAC _) ctx) = liftIO $ Low.macSetNonce ctx n
+setGMACNonce _ _                               = return ()
 
 -- Accessory functions
 

--- a/botan/src/Botan/MAC/CMAC.hs
+++ b/botan/src/Botan/MAC/CMAC.hs
@@ -1,16 +1,17 @@
-module Botan.MAC.CMAC
-( CMAC(..)
-, CMACKey(..)
-, CMACAuth(..)
-, cmac
-, cmacLazy
-, newCMACKey
-) where
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.MAC.CMAC (
+    CMAC
+  , CMACKey
+  , CMACAuth
+  , cmac
+  , cmacLazy
+  , newCMACKey
+  ) where
 
 import           Data.Maybe
 import           Data.Proxy
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 
@@ -19,7 +20,6 @@ import qualified Botan.MAC as Botan
 import qualified Botan.Utility as Botan
 
 import           Botan.BlockCipher.AES
-import           Botan.BlockCipher.Class
 import           Botan.MAC.Class
 import           Botan.Prelude
 
@@ -30,7 +30,7 @@ import           Botan.RNG
 data CMAC bc
 
 newtype instance MACKey (CMAC bc) = CMACKey
-    { getCMACKey :: ByteString {- ByteVector n -} }
+    { _getCMACKey :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (MACKey (CMAC bc)) where
@@ -40,7 +40,7 @@ instance Show (MACKey (CMAC bc)) where
 type CMACKey bc = MACKey (CMAC bc)
 
 newtype instance MACAuth (CMAC bc) = CMACAuth
-    { getCMACAuth :: ByteString {- ByteVector n -} }
+    { _getCMACAuth :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 instance Show (MACAuth (CMAC bc)) where
@@ -86,8 +86,9 @@ instance BotanBlockCipher AES128 where
 class BotanMAC mac where
     botanMAC :: Proxy mac -> Botan.MAC
 instance (BotanBlockCipher bc) => BotanMAC (CMAC bc) where
-    botanMAC :: BotanBlockCipher bc => Proxy (CMAC bc) -> Botan.MAC
+    botanMAC :: Proxy (CMAC bc) -> Botan.MAC
     botanMAC _ = Botan.cmac (botanBlockCipher $ Proxy @bc)
+
 instance (BotanBlockCipher bc) => MAC (CMAC bc) where
     mac :: MACKey (CMAC bc) -> ByteString -> MACAuth (CMAC bc)
     mac (CMACKey k) = CMACAuth . fromJust . Botan.mac (botanMAC $ Proxy @(CMAC bc)) k

--- a/botan/src/Botan/MAC/Class.hs
+++ b/botan/src/Botan/MAC/Class.hs
@@ -1,12 +1,15 @@
-module Botan.MAC.Class
-( MAC(..)
-, MACKey(..)
-, MACAuth(..)
-, macProxy
-, macFile
-, IncrementalMAC(..)
-, macFileLazy
-) where
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Botan.MAC.Class (
+    MAC (..)
+  , MACKey
+  , MACAuth
+  , macProxy
+  , macFile
+  , IncrementalMAC(..)
+  , macFileLazy
+  ) where
 
 import           Botan.Prelude
 
@@ -36,7 +39,7 @@ macProxy _ = mac
 macFile :: (MAC mac, MonadIO m) => MACKey mac -> FilePath -> m (MACAuth mac)
 macFile k fp = mac k <$> liftIO (ByteString.readFile fp)
 
-class (MAC mac) => IncrementalMAC mac where
+class IncrementalMAC mac where
     macLazy :: MACKey mac -> Lazy.ByteString -> MACAuth mac
 
 macFileLazy :: (IncrementalMAC mac, MonadIO m) => MACKey mac -> FilePath -> m (MACAuth mac)

--- a/botan/src/Botan/OneTimeAuth/Class.hs
+++ b/botan/src/Botan/OneTimeAuth/Class.hs
@@ -1,13 +1,16 @@
-module Botan.OneTimeAuth.Class
-( OneTimeAuth(..)
-, OneTimeAuthKey(..)
-, OneTimeAuthNonce(..)
-, OneTimeAuthCode(..)
-, oneTimeAuthProxy
-, oneTimeAuthFile
-, IncrementalOneTimeAuth(..)
-, oneTimeAuthFileLazy
-) where
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Botan.OneTimeAuth.Class (
+    OneTimeAuth(..)
+  , OneTimeAuthKey
+  , OneTimeAuthNonce
+  , OneTimeAuthCode
+  , oneTimeAuthProxy
+  , oneTimeAuthFile
+  , IncrementalOneTimeAuth(..)
+  , oneTimeAuthFileLazy
+  ) where
 
 import           Botan.Prelude
 
@@ -21,14 +24,6 @@ import qualified Data.ByteString.Lazy as Lazy
 data family OneTimeAuthKey ota
 data family OneTimeAuthNonce ota
 data family OneTimeAuthCode ota
-
--- Invariant: The key and nonce must never be re-used together.
-type OneTimeKey ota = (OneTimeAuthKey ota, OneTimeAuthNonce ota)
--- TODO: Decide whether to `SeparateKey ota -> SeparateNonce ota -> ...`
---  or `CombinedOneTimeKey ota -> ...`
--- Note that this is a different meaning of `Combined` than as used in `saltine`.
--- We mean `Combined` as the opposite of `Detached` in saltine.
--- TODO: Prefer `Attached` terminology?
 
 class OneTimeAuth ota where
     oneTimeAuth :: OneTimeAuthKey ota -> OneTimeAuthNonce ota -> ByteString -> OneTimeAuthCode ota
@@ -44,7 +39,7 @@ oneTimeAuthProxy _ = oneTimeAuth
 oneTimeAuthFile :: (OneTimeAuth ota, MonadIO m) => OneTimeAuthKey ota -> OneTimeAuthNonce ota -> FilePath -> m (OneTimeAuthCode ota)
 oneTimeAuthFile k n fp = oneTimeAuth k n <$> liftIO (ByteString.readFile fp)
 
-class (OneTimeAuth ota) => IncrementalOneTimeAuth ota where
+class IncrementalOneTimeAuth ota where
     oneTimeAuthLazy :: OneTimeAuthKey ota -> OneTimeAuthNonce ota -> Lazy.ByteString -> OneTimeAuthCode ota
 
 oneTimeAuthFileLazy :: (IncrementalOneTimeAuth ota, MonadIO m) => OneTimeAuthKey ota -> OneTimeAuthNonce ota -> FilePath -> m (OneTimeAuthCode ota)

--- a/botan/src/Botan/OneTimeAuth/Poly1305.hs
+++ b/botan/src/Botan/OneTimeAuth/Poly1305.hs
@@ -1,20 +1,18 @@
-module Botan.OneTimeAuth.Poly1305
-( Poly1305(..)
-, Poly1305OneTimeAuthKey(..)
-, Poly1305OneTimeAuthNonce(..)
-, Poly1305OneTimeAuthCode(..)
-, poly1305OneTimeAuth
--- , poly1305AuthOneTimeAuthLazy
-) where
+{-# LANGUAGE TypeFamilies #-}
+
+module Botan.OneTimeAuth.Poly1305 (
+    Poly1305
+  , Poly1305OneTimeAuthKey
+  , Poly1305OneTimeAuthNonce
+  , Poly1305OneTimeAuthCode
+  , poly1305OneTimeAuth
+  ) where
 
 import           Data.Maybe
 
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Text as Text
 
 import qualified Botan.MAC as Botan
-import qualified Botan.Utility as Botan
 
 import           Botan.OneTimeAuth.Class
 import           Botan.Prelude
@@ -24,7 +22,7 @@ import           Botan.Prelude
 data Poly1305
 
 newtype instance OneTimeAuthKey Poly1305 = Poly1305OneTimeAuthKey
-    { getPoly1305OneTimeAuthKey :: ByteString {- ByteVector n -} }
+    { _getPoly1305OneTimeAuthKey :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type Poly1305OneTimeAuthKey = OneTimeAuthKey Poly1305
@@ -39,7 +37,7 @@ newtype instance OneTimeAuthNonce Poly1305 = Poly1305OneTimeAuthNonce
 type Poly1305OneTimeAuthNonce = OneTimeAuthNonce Poly1305
 
 newtype instance OneTimeAuthCode Poly1305 = Poly1305OneTimeAuthCode
-    { getPoly1305OneTimeAuthCode :: ByteString {- ByteVector n -} }
+    { _getPoly1305OneTimeAuthCode :: ByteString {- ByteVector n -} }
     deriving newtype (Eq, Ord)
 
 type Poly1305OneTimeAuthCode = OneTimeAuthCode Poly1305

--- a/botan/src/Botan/Padding.hs
+++ b/botan/src/Botan/Padding.hs
@@ -1,4 +1,26 @@
-module Botan.Padding where
+module Botan.Padding (
+    Padding (..)
+  , Pad (..)
+  , EME
+  , EMSA
+  , pad
+  , padBitPadding
+  , padBytePadding
+  , padANSI_X9_23
+  , padISO_10126
+  , padPKCS_7
+  , padISO_IEC_7816_4
+  , padZeroPadding
+  , padTo
+  , padMul
+  , padBlockMul
+  , padBy
+  , padCount
+  , padLength
+  , Padded
+  , BytePadding (..)
+  , BitPadding (..)
+  ) where
 
 -- NOTE: Botan does not expose padding functions directly
 --  We will implement them here as a utility
@@ -15,7 +37,7 @@ module Botan.Padding where
 --  Botan.Low.Prelude.paddingInfo
 
 import           Botan.Hash
-import           Botan.Prelude
+import           Botan.Prelude hiding (length)
 
 data Padding
     = Pad Pad
@@ -38,6 +60,7 @@ data EMSA   -- ...
 
 pad :: Pad -> Int -> ByteString -> ByteString
 pad BitPadding i bs = undefined $ padBitPadding i (undefined bs)
+pad _ _ _           = undefined
 
 padBitPadding :: Int -> [Bool] -> [Bool]
 padBitPadding = undefined
@@ -58,7 +81,7 @@ padISO_IEC_7816_4 :: Int -> ByteString -> ByteString
 padISO_IEC_7816_4 = undefined
 
 padZeroPadding :: Int -> ByteString -> ByteString
-padZeroPadding i = undefined
+padZeroPadding _i = undefined
 
 -- NOTE: (padCount,finalLength)
 padTo :: Int -> Int -> (Int,Int)

--- a/botan/src/Botan/Prelude.hs
+++ b/botan/src/Botan/Prelude.hs
@@ -1,40 +1,40 @@
-module Botan.Prelude
-( module Prelude
-, module Control.Applicative
-, module Control.Monad
-, module Control.Monad.IO.Class
-, module Control.Exception
-, module Control.DeepSeq
-, module Data.Bits
-, module Data.ByteString
-, module Data.Text
-, module Data.Foldable
-, module Data.Word
-, module System.IO
-, module System.IO.Unsafe
-, module GHC.Stack
-, Message(..)
-, Ciphertext(..)
-, LazyCiphertext(..)
-, Plaintext(..)
-, unsafePerformIO1
-, unsafePerformIO2
-, unsafePerformIO3
-, unsafePerformIO4
--- , strictReturn
--- , strictly
--- , strictPerformIO
--- , strictPerformIO1
--- , strictPerformIO2
--- , strictPerformIO3
-, showText
-, showBytes
---
-, module Data.IORef
-, track
---
-, splitBlocks
-) where
+module Botan.Prelude (
+    module Prelude
+  , module Control.Applicative
+  , module Control.Monad
+  , module Control.Monad.IO.Class
+  , module Control.Exception
+  , module Control.DeepSeq
+  , module Data.Bits
+  , module Data.ByteString
+  , module Data.Text
+  , module Data.Foldable
+  , module Data.Word
+  , module System.IO
+  , module System.IO.Unsafe
+  , module GHC.Stack
+  , Message
+  , Ciphertext
+  , LazyCiphertext
+  , Plaintext
+  , unsafePerformIO1
+  , unsafePerformIO2
+  , unsafePerformIO3
+  , unsafePerformIO4
+  -- , strictReturn
+  -- , strictly
+  -- , strictPerformIO
+  -- , strictPerformIO1
+  -- , strictPerformIO2
+  -- , strictPerformIO3
+  , showText
+  , showBytes
+  --
+  , module Data.IORef
+  , track
+  --
+  , splitBlocks
+  ) where
 
 -- Re-exported modules
 
@@ -165,19 +165,6 @@ track val = do
         ( unsafePerformIO (writeIORef ref True) `seq` val
         , readIORef ref
         )
-
--- A name type
-
-data Name
-    = Name ByteString           -- Foo
-    | NameFn ByteString [Name]  -- Foo(a,b,...,c)
-    | Names [Name]              -- a/b/.../c
-    | Param Int
-
-nameBytes :: Name -> ByteString
-nameBytes (Name name) = name
-nameBytes (NameFn name args) = name <> "(" <> inner <> ")" where
-    inner = ByteString.intercalate "," $ fmap nameBytes args
 
 -- TODO: Name parser
 

--- a/botan/src/Botan/PubKey.hs
+++ b/botan/src/Botan/PubKey.hs
@@ -12,85 +12,84 @@ Public key cryptography is a collection of techniques allowing
 for encryption, signatures, and key agreement.
 -}
 
-module Botan.PubKey
-(
+module Botan.PubKey (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Idiomatic interface
+  -- * Idiomatic interface
 
--- ** Data type
-  PK(..)
--- TODO: Rename XMSSScheme
-, XMSS(..)
-, ECGroup(..)
-, ecGroupName
-, DLGroup(..)
-, dlGroupName
+  -- ** Data type
+    PK(..)
+  -- TODO: Rename XMSSScheme
+  , XMSS(..)
+  , ECGroup(..)
+  , ecGroupName
+  , DLGroup(..)
+  , dlGroupName
 
--- ** Enumerations
+  -- ** Enumerations
 
--- , allPKs
+  -- , allPKs
 
--- ** Associated types
+  -- ** Associated types
 
-, PKExportFormat(..)
-, pkExportFormatFlags
-, PKCheckKeyFlags(..)
-, PKPadding(..)
-, pkPaddingName
+  , PKExportFormat(..)
+  , pkExportFormatFlags
+  , PKCheckKeyFlags(..)
+  , PKPadding(..)
+  , pkPaddingName
 
--- * Private Keys
+  -- * Private Keys
 
--- ** Wrapped private key
-, PrivKey(..)
+  -- ** Wrapped private key
+  , PrivKey(..)
 
--- ** Destructor
-, destroyPrivKey
+  -- ** Destructor
+  , destroyPrivKey
 
--- ** Initializers
-, newPrivKey
+  -- ** Initializers
+  , newPrivKey
 
--- ** Accessors
+  -- ** Accessors
 
-, privKeyAlgo
-, privKeyField
+  , privKeyAlgo
+  , privKeyField
 
--- ** Accessory functions
-, loadPrivKey
-, exportPrivKey
-, exportPrivKeyPubKey
-, checkPrivKey
+  -- ** Accessory functions
+  , loadPrivKey
+  , exportPrivKey
+  , exportPrivKeyPubKey
+  , checkPrivKey
 
--- * Public Keys
+  -- * Public Keys
 
-, PubKey(..)
+  , PubKey(..)
 
--- ** Destructor
-, destroyPubKey
+  -- ** Destructor
+  , destroyPubKey
 
--- ** Accessors
+  -- ** Accessors
 
-, pubKeyAlgo
-, pubKeyField
-, estimatedPubKeyStrength
-, pubKeyFingerprint
+  , pubKeyAlgo
+  , pubKeyField
+  , estimatedPubKeyStrength
+  , pubKeyFingerprint
 
--- ** Accessory functions
+  -- ** Accessory functions
 
-, loadPubKey
-, exportPubKey
-, checkPubKey
+  , loadPubKey
+  , exportPubKey
+  , checkPubKey
 
---
+  --
 
-, privKeyCreatePKIO
+  , privKeyCreatePKIO
 
-) where
+  ) where
 
 import           Botan.Low.MPI
 import           Botan.Low.PubKey (PrivKey (..), PubKey (..))
@@ -256,7 +255,7 @@ checkPubKey :: (MonadRandomIO m) => PubKey -> Bool -> m Bool
 checkPubKey pk expensive = do
     rng <- getRNG
     -- TODO: Return false on catch error
-    liftIO $ Low.pubKeyCheckKey pk rng (bool Low.CheckKeyNormalTests Low.CheckKeyExpensiveTests expensive)
+    void $ liftIO $ Low.pubKeyCheckKey pk rng (bool Low.CheckKeyNormalTests Low.CheckKeyExpensiveTests expensive)
     return True
 
 
@@ -511,7 +510,6 @@ pkPaddingName (EME_OAEP h m l) = case (m,l) of
     (Just m', Just l') -> "OAEP(" <> hashName h <> ",MGF1(" <> hashName m' <> ")," <> l' <> ")"
 pkPaddingName (SM2EncParam h)  = hashName h
 
-defaultPKPadding = "OAEP(SHA-256)" -- C++ docs tell us more about this
 
 -- SEE: C++ Docs on more types, eg MGF1:
 --  MGF1: https://botan.randombit.net/doxygen/mgf1_8h_source.html

--- a/botan/src/Botan/PubKey/Decrypt.hs
+++ b/botan/src/Botan/PubKey/Decrypt.hs
@@ -9,47 +9,42 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.Decrypt
-(
+module Botan.PubKey.Decrypt (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Public Key Decryption
+  -- * Public Key Decryption
 
-  pkDecrypt
-, pkDecryptOutputLength
+    pkDecrypt
+  , pkDecryptOutputLength
 
--- * Mutable interface
+  -- * Mutable interface
 
--- ** Data type
-, PKDecrypt(..)
+  -- ** Data type
+  , PKDecrypt
 
--- ** Destructor
-, destroyPKDecrypt
+  -- ** Destructor
+  , destroyPKDecrypt
 
--- ** Initializers
-, newPKDecrypt
+  -- ** Initializers
+  , newPKDecrypt
 
--- ** Accessors
-, getPKDecryptOutputLength
+  -- ** Accessors
+  , getPKDecryptOutputLength
 
--- ** Algorithm
-, pkDecryptWith
+  -- ** Algorithm
+  , pkDecryptWith
 
-) where
-
-import qualified Data.ByteString as ByteString
+  ) where
 
 import qualified Botan.Low.PubKey.Decrypt as Low
 
-import           Botan.Error
 import           Botan.Prelude
 import           Botan.PubKey
-import           Botan.RNG
 
 
 {- $introduction

--- a/botan/src/Botan/PubKey/Encrypt.hs
+++ b/botan/src/Botan/PubKey/Encrypt.hs
@@ -9,42 +9,38 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.Encrypt
-(
+module Botan.PubKey.Encrypt (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Public Key Encryption
+  -- * Public Key Encryption
 
-  pkEncrypt
-, pkEncryptOutputLength
+    pkEncrypt
+  , pkEncryptOutputLength
 
--- ** Data type
-, PKEncrypt(..)
+  -- ** Data type
+  , PKEncrypt
 
--- ** Destructor
-, destroyPKEncrypt
+  -- ** Destructor
+  , destroyPKEncrypt
 
--- ** Initializers
-, newPKEncrypt
+  -- ** Initializers
+  , newPKEncrypt
 
--- ** Accessors
-, getPKEncryptOutputLength
+  -- ** Accessors
+  , getPKEncryptOutputLength
 
--- ** Algorithm
-, pkEncryptWith
+  -- ** Algorithm
+  , pkEncryptWith
 
-) where
-
-import qualified Data.ByteString as ByteString
+  ) where
 
 import qualified Botan.Low.PubKey.Encrypt as Low
 
-import           Botan.Error
 import           Botan.Prelude
 import           Botan.PubKey
 import           Botan.RNG

--- a/botan/src/Botan/PubKey/KeyEncapsulation.hs
+++ b/botan/src/Botan/PubKey/KeyEncapsulation.hs
@@ -9,74 +9,69 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.KeyEncapsulation
-(
+module Botan.PubKey.KeyEncapsulation (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * KEM Encryption
+  -- * KEM Encryption
 
-  kemEncrypt
-, kemDecrypt
+    kemEncrypt
+  , kemDecrypt
 
--- ** Associated types
+  -- ** Associated types
 
-, KEMSharedKey(..)
-, KEMEncapsulatedKey(..)
+  , KEMSharedKey
+  , KEMEncapsulatedKey
 
--- ** Accessors
+  -- ** Accessors
 
-, kemSharedKeyLength
-, kemEncapsulatedKeyLength
+  , kemSharedKeyLength
+  , kemEncapsulatedKeyLength
 
--- ** Data type
-,  KEMEncrypt(..)
+  -- ** Data type
+  ,  KEMEncrypt
 
--- ** Destructor
-, destroyKEMEncrypt
+  -- ** Destructor
+  , destroyKEMEncrypt
 
--- ** Initializers
-, newKEMEncrypt
+  -- ** Initializers
+  , newKEMEncrypt
 
--- ** Accessors
-, kemEncryptSharedKeyLength
-, kemEncryptEncapsulatedKeyLength
+  -- ** Accessors
+  , kemEncryptSharedKeyLength
+  , kemEncryptEncapsulatedKeyLength
 
--- ** Mutable Algorithm
-, kemEncryptCreateSharedKey
+  -- ** Mutable Algorithm
+  , kemEncryptCreateSharedKey
 
--- * KEM Decryption
+  -- * KEM Decryption
 
--- ** Data type
-, KEMDecrypt(..)
+  -- ** Data type
+  , KEMDecrypt
 
--- ** Destructor
-, destroyKEMDecrypt
+  -- ** Destructor
+  , destroyKEMDecrypt
 
--- ** Initializers
-, newKEMDecrypt
+  -- ** Initializers
+  , newKEMDecrypt
 
--- ** Accessors
-, kemDecryptSharedKeyLength
+  -- ** Accessors
+  , kemDecryptSharedKeyLength
 
--- ** Mutable Algorithm
-, kemDecryptSharedKey
+  -- ** Mutable Algorithm
+  , kemDecryptSharedKey
 
-) where
-
-import qualified Data.ByteString as ByteString
+  ) where
 
 import qualified Botan.Low.PubKey.KeyEncapsulation as Low
 
-import           Botan.Error
 import           Botan.KDF
 import           Botan.Prelude
 import           Botan.PubKey
-import           Botan.RNG
 
 {- $introduction
 
@@ -90,8 +85,10 @@ import           Botan.RNG
 -- Idiomatic interface
 --
 
+kemEncrypt :: a
 kemEncrypt = undefined
 
+kemDecrypt :: a
 kemDecrypt = undefined
 
 -- Associated types
@@ -101,8 +98,10 @@ type KEMEncapsulatedKey = Low.KEMEncapsulatedKey
 
 -- Accessors
 
+kemSharedKeyLength :: a
 kemSharedKeyLength = undefined
 
+kemEncapsulatedKeyLength :: a
 kemEncapsulatedKeyLength = undefined
 
 
@@ -118,27 +117,27 @@ data KEMEncrypt
 
 -- Destructor
 
-destroyKEMEncrypt :: (MonadIO m) => KEMEncrypt -> m ()
+destroyKEMEncrypt :: KEMEncrypt -> m ()
 destroyKEMEncrypt = undefined
 
 -- Initializers
 
-newKEMEncrypt :: (MonadIO m) => PubKey -> KDF -> m KEMEncrypt
+newKEMEncrypt :: PubKey -> KDF -> m KEMEncrypt
 newKEMEncrypt = undefined
 
 -- Accessors
 
-kemEncryptEncapsulatedKeyLength :: (MonadIO m) => KEMEncrypt -> m Int
+kemEncryptEncapsulatedKeyLength :: KEMEncrypt -> m Int
 kemEncryptEncapsulatedKeyLength = undefined
 
 -- Accessory functions
 
-kemEncryptSharedKeyLength :: (MonadIO m) => KEMEncrypt -> Int -> m Int
+kemEncryptSharedKeyLength :: KEMEncrypt -> Int -> m Int
 kemEncryptSharedKeyLength = undefined
 
 -- Mutable algorithm
 
-kemEncryptCreateSharedKey :: (MonadRandomIO m) => KEMEncrypt -> ByteString -> Int -> m (KEMSharedKey,KEMEncapsulatedKey)
+kemEncryptCreateSharedKey :: KEMEncrypt -> ByteString -> Int -> m (KEMSharedKey,KEMEncapsulatedKey)
 kemEncryptCreateSharedKey = undefined
 
 -- KEM Decryption
@@ -147,20 +146,20 @@ data KEMDecrypt
 
 -- Destructor
 
-destroyKEMDecrypt  :: (MonadIO m) => KEMDecrypt -> m ()
+destroyKEMDecrypt  :: KEMDecrypt -> m ()
 destroyKEMDecrypt = undefined
 
 -- Initializers
 
-newKEMDecrypt :: (MonadIO m) => PrivKey -> KDF -> m KEMDecrypt
+newKEMDecrypt :: PrivKey -> KDF -> m KEMDecrypt
 newKEMDecrypt = undefined
 
 -- Accessory functions
 
-kemDecryptSharedKeyLength :: (MonadIO m) => KEMDecrypt -> Int -> m Int
+kemDecryptSharedKeyLength :: KEMDecrypt -> Int -> m Int
 kemDecryptSharedKeyLength = undefined
 
 -- Mutable algorithm
 
-kemDecryptSharedKey :: (MonadIO m) => KEMDecrypt -> ByteString -> KEMEncapsulatedKey -> Int -> m KEMSharedKey
+kemDecryptSharedKey :: KEMDecrypt -> ByteString -> KEMEncapsulatedKey -> Int -> m KEMSharedKey
 kemDecryptSharedKey  = undefined

--- a/botan/src/Botan/PubKey/Load.hs
+++ b/botan/src/Botan/PubKey/Load.hs
@@ -9,52 +9,51 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.Load
-(
+module Botan.PubKey.Load (
 
--- * DH
-  loadDHPrivKey
-, loadDHPubKey
+  -- * DH
+    loadDHPrivKey
+  , loadDHPubKey
 
--- * DSA
-, newDSAPrivKey
-, loadDSAPrivKey
-, loadDSAPubKey
+  -- * DSA
+  , newDSAPrivKey
+  , loadDSAPrivKey
+  , loadDSAPubKey
 
--- * ECDH
-, loadECDHPrivKey
-, loadECDHPubKey
+  -- * ECDH
+  , loadECDHPrivKey
+  , loadECDHPubKey
 
--- * ECDSA
-, loadECDSAPrivKey
-, loadECDSAPubKey
+  -- * ECDSA
+  , loadECDSAPrivKey
+  , loadECDSAPubKey
 
--- * Ed25519
-, loadEd25519PrivKey
-, loadEd25519PubKey
-, exportEd25519PrivKey
-, exportEd25519PubKey
+  -- * Ed25519
+  , loadEd25519PrivKey
+  , loadEd25519PubKey
+  , exportEd25519PrivKey
+  , exportEd25519PubKey
 
--- * ElGamal
-, newElGamalPrivKey
-, loadElGamalPrivKey
-, loadElGamalPubKey
+  -- * ElGamal
+  , newElGamalPrivKey
+  , loadElGamalPrivKey
+  , loadElGamalPubKey
 
--- * RSA
-, loadRSAPrivKey
-, loadRSAPubKey
+  -- * RSA
+  , loadRSAPrivKey
+  , loadRSAPubKey
 
--- * SM2
-, loadSM2PrivKey
-, loadSM2PubKey
+  -- * SM2
+  , loadSM2PrivKey
+  , loadSM2PubKey
 
--- * X25519
-, loadX25519PrivKey
-, loadX25519PubKey
-, exportX25519PrivKey
-, exportX25519PubKey
+  -- * X25519
+  , loadX25519PrivKey
+  , loadX25519PubKey
+  , exportX25519PrivKey
+  , exportX25519PubKey
 
-) where
+  ) where
 
 import qualified Botan.Low.PubKey.DH as Low
 import qualified Botan.Low.PubKey.DSA as Low
@@ -66,7 +65,6 @@ import qualified Botan.Low.PubKey.RSA as Low
 import qualified Botan.Low.PubKey.SM2 as Low
 import qualified Botan.Low.PubKey.X25519 as Low
 
-import           Botan.Error
 import           Botan.Prelude
 import           Botan.PubKey
 import           Botan.RNG

--- a/botan/src/Botan/PubKey/Sign.hs
+++ b/botan/src/Botan/PubKey/Sign.hs
@@ -9,48 +9,47 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.Sign
-(
+module Botan.PubKey.Sign (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Public Key Signatures
+  -- * Public Key Signatures
 
-  pkSign
--- , pkSignatureLength
+    pkSign
+  -- , pkSignatureLength
 
--- ** Data type
-,  PKSign(..)
+  -- ** Data type
+  , PKSign
 
--- ** Associated types
+  -- ** Associated types
 
-, PKSignAlgo(..)
-, signAlgoName
-, PKSignatureFormat(..)
-, PKSignature(..)
+  , PKSignAlgo
+  , signAlgoName
+  , PKSignatureFormat
+  , PKSignature
 
--- ** Destructor
-, destroyPKSign
+  -- ** Destructor
+  , destroyPKSign
 
--- ** Initializers
-, newPKSign
+  -- ** Initializers
+  , newPKSign
 
--- ** Accessors
-, pkSignOutputLength
+  -- ** Accessors
+  , pkSignOutputLength
 
--- ** Algorithm
-, pkSignUpdate
-, pkSignFinish
+  -- ** Algorithm
+  , pkSignUpdate
+  , pkSignFinish
 
--- PENDING REFACTOR
-, SignAlgo(..)
-, EMSA(..)
+  -- PENDING REFACTOR
+  , SignAlgo(..)
+  , EMSA(..)
 
-) where
+  ) where
 
 import qualified Data.ByteString as ByteString
 
@@ -59,7 +58,6 @@ import           Data.Bool
 import qualified Botan.Low.PubKey as Low
 import qualified Botan.Low.PubKey.Sign as Low
 
-import           Botan.Error
 import           Botan.Hash
 import           Botan.Prelude
 import           Botan.PubKey
@@ -163,29 +161,7 @@ data SignAlgo
     | Ed25519Hash Hash  -- NOTE: Ed25519 is not the only key type to accept arbitary hashes.
     | SM2SignParam ByteString Hash
     | XMSSEmptyParam
-    deriving (Show, Eq)
-
-{- REFACTORING STAB 1 -}
-
-data PKSignAlgo'
-    = RSASign' EMSA
-    | SM2Sign' ByteString Hash
-    | DSASign' Hash
-    | ECDSASign' Hash
-    | ECKCDSASign' Hash
-    | ECGDSASign' Hash
-    | GOST_34_10Sign' Hash
-    | Ed25519Sign' Ed25519Sign'
-    | XMSSSign' -- NOTE: Probably has actual params
-    | DilithiumSign' -- NOTE: Probably has actual params
-
-data Ed25519Sign'
-    = Ed25519Pure'
-    | Ed25519ph'
-    | Ed25519Hash' Hash
-    | Ed25519Empty' -- NOTE: SUSPECT DEFAULTS TO ONE OF THE OTHERS
-
-{- END REFACTORING STAB 1 -}
+    deriving stock (Show, Eq)
 
 signAlgoName :: SignAlgo -> Low.EMSAName
 signAlgoName (EMSA emsa)          = emsaName emsa
@@ -207,7 +183,7 @@ data EMSA
     | EMSA4 Hash (Maybe Int)
     | ISO_9796_DS2 Hash Bool (Maybe Int)
     | ISO_9796_DS3 Hash Bool
-    deriving (Show, Eq)
+    deriving stock (Show, Eq)
 
 -- TODO: Use elsewhere
 mkNameArgs :: ByteString -> [ByteString] -> ByteString
@@ -237,9 +213,5 @@ iso9796Implicit = bool "exp" "imp"
 data SignatureFormat
     = StandardFormat
     | DERFormat
-    deriving (Show, Eq)
-
-signatureFormatFlag :: SignatureFormat -> Low.SigningFlags
-signatureFormatFlag StandardFormat = Low.StandardFormatSignature -- BOTAN_PUBKEY_SIGNING_FLAGS_NONE
-signatureFormatFlag DERFormat      = Low.DERFormatSignature -- BOTAN_PUBKEY_DER_FORMAT_SIGNATURE
+    deriving stock (Show, Eq)
 

--- a/botan/src/Botan/PubKey/Verify.hs
+++ b/botan/src/Botan/PubKey/Verify.hs
@@ -9,40 +9,36 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-module Botan.PubKey.Verify
-(
+module Botan.PubKey.Verify (
 
--- * Thing
--- $introduction
+  -- * Thing
+  -- $introduction
 
--- * Usage
--- $usage
+  -- * Usage
+  -- $usage
 
--- * Public Key Signature Verification
+  -- * Public Key Signature Verification
 
--- TODO: Rename pkVerifySignature?
-  pkVerify
+  -- TODO: Rename pkVerifySignature?
+    pkVerify
 
--- ** Data type
-, PKVerify(..)
+  -- ** Data type
+  , PKVerify
 
--- ** Destructor
-, destroyPKVerify
+  -- ** Destructor
+  , destroyPKVerify
 
--- ** Initializers
-, newPKVerify
+  -- ** Initializers
+  , newPKVerify
 
--- ** Algorithm
-, pkVerifyUpdate
-, pkVerifyFinish
+  -- ** Algorithm
+  , pkVerifyUpdate
+  , pkVerifyFinish
 
-) where
-
-import qualified Data.ByteString as ByteString
+  ) where
 
 import qualified Botan.Low.PubKey.Verify as Low
 
-import           Botan.Error
 import           Botan.Prelude
 import           Botan.PubKey
 import           Botan.PubKey.Sign

--- a/botan/src/Botan/PwdHash.hs
+++ b/botan/src/Botan/PwdHash.hs
@@ -1,6 +1,14 @@
-module Botan.PwdHash where
+module Botan.PwdHash (
+    pwdhash
+  , pwdhashTimed
+  , PBKDF (..)
+  , pbkdfName
+  , PBKDFParams
+  , pbkdfParams
+  , pbkdfParamsNone
+  ) where
 
-import           Botan.Low.PwdHash (PBKDFName (..))
+import           Botan.Low.PwdHash (PBKDFName)
 import qualified Botan.Low.PwdHash as Low
 
 import           Botan.Hash
@@ -49,13 +57,13 @@ data PBKDF
     | OpenPGP_S2K Hash Int  -- Iterations
 
 pbkdfName :: PBKDF -> PBKDFName
-pbkdfName (PBKDF2 m _)      = Low.pbkdf2 (macName m)
-pbkdfName (Scrypt n r p)    = Low.Scrypt
-pbkdfName (Argon2d i m p)   = Low.Argon2d
-pbkdfName (Argon2i i m p)   = Low.Argon2i
-pbkdfName (Argon2id i m p)  = Low.Argon2id
-pbkdfName (Bcrypt i)        = Low.Bcrypt_PBKDF
-pbkdfName (OpenPGP_S2K h _) = Low.openPGP_S2K (hashName h)
+pbkdfName (PBKDF2 m _)        = Low.pbkdf2 (macName m)
+pbkdfName (Scrypt _n _r _p)   = Low.Scrypt
+pbkdfName (Argon2d _i _m _p)  = Low.Argon2d
+pbkdfName (Argon2i _i _m _p)  = Low.Argon2i
+pbkdfName (Argon2id _i _m _p) = Low.Argon2id
+pbkdfName (Bcrypt _i)         = Low.Bcrypt_PBKDF
+pbkdfName (OpenPGP_S2K h _)   = Low.openPGP_S2K (hashName h)
 
 type PBKDFParams = (Int,Int,Int)
 

--- a/botan/src/Botan/RNG.hs
+++ b/botan/src/Botan/RNG.hs
@@ -11,72 +11,61 @@ Portability : POSIX
 A module for the common task of random number generation.
 -}
 
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE FunctionalDependencies     #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE MagicHash                  #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeSynonymInstances       #-}
+-- TODO: replace the orphan instance by a non-orphan instance or deriving-via
+-- mechanism. See issue #56.
+{-# OPTIONS_GHC -Wno-orphans #-}
 
-module Botan.RNG
-(
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
 
--- * Random Number Generators
--- $introduction
+module Botan.RNG (
 
--- * Usage
--- $usage
+  -- * Random Number Generators
+  -- $introduction
 
--- * The RNG data type
-  RNG(..)
+  -- * Usage
+  -- $usage
 
--- * Available RNGs
-, RNGType(..)
+  -- * The RNG data type
+    RNG
 
--- * Initializing a random number generator
-, newRNG
-, systemRNG
+  -- * Available RNGs
+  , RNGType(..)
 
--- * Getting random bytes directly
-, getRandomBytesRNG
-, unsafeGetRandomBytesRNG
+  -- * Initializing a random number generator
+  , newRNG
+  , systemRNG
 
--- * Adding entropy directly
-, addEntropyRNG
-, reseedRNG
-, reseedRNGFrom
+  -- * Getting random bytes directly
+  , getRandomBytesRNG
+  , unsafeGetRandomBytesRNG
 
--- * IO with implicit RNG
-, MonadRandomIO(..)
+  -- * Adding entropy directly
+  , addEntropyRNG
+  , reseedRNG
+  , reseedRNGFrom
 
--- * Getting random bytes
-, getRandomBytes
-, getSystemRandomBytes
+  -- * IO with implicit RNG
+  , MonadRandomIO(..)
 
--- * Adding entropy
-, reseed
-, reseedFrom
-, addEntropy
+  -- * Getting random bytes
+  , getRandomBytes
+  , getSystemRandomBytes
 
--- * RandomIO monad
-, RandomIO(..)
-, runRandomIO
+  -- * Adding entropy
+  , reseed
+  , reseedFrom
+  , addEntropy
 
--- * RandomT monad transformer
-, RandomT(..)
-, runRandomT
+  -- * RandomIO monad
+  , RandomIO
+  , runRandomIO
 
-) where
+  -- * RandomT monad transformer
+  , RandomT
+  , runRandomT
 
-import           Control.Concurrent.MVar
-
-import           Data.Bifunctor
-import           Data.Tuple
+  ) where
 
 import qualified Data.ByteString as ByteString
 
@@ -167,7 +156,7 @@ data RNGType
     | RDRand        -- ^ Hardware random `Processor_RNG`, may be unavailable
 
     -- CustomRNG ...
-    deriving (Eq, Show)
+    deriving stock (Eq, Show)
 
 type RNGName = Low.RNGType
 
@@ -328,7 +317,7 @@ instance (MonadIO m) => MonadRandomIO (ReaderT RNG m) where
     getRNG = ask
 
 -- | Runs a `MonadRandomIO` action in `MonadIO` using the specified generator.
-runRandomT :: (MonadIO m) => RandomT m a -> RNG -> m a
+runRandomT :: RandomT m a -> RNG -> m a
 runRandomT = runReaderT
 
 -- | Random generator monad
@@ -364,180 +353,3 @@ addEntropy
     => ByteString   -- ^ entropy
     -> m ()
 addEntropy entropy = getRNG >>= addEntropyRNG entropy
-
---
--- We can make RNG conform to the experimental typeclasses
---
-
-instance RNG' RNG where
-
-    generateRandomBytes' :: Int -> RNG -> IO ByteString
-    generateRandomBytes' = getRandomBytesRNG
-
-    addEntropyRNG' :: ByteString -> RNG -> IO ()
-    addEntropyRNG' = addEntropyRNG
-
---
--- EXPERIMENTS TO BE MOVED TO CRYPTO-SCHEMES
---
-
--- TODO: More stringently define difference between:
---      - seeding (initializing or setting the RNG to a specific state)
---      - reseeding (adding entropy that gets mixed with the curent state)
--- NOTE: NIST DRBG standards support this use of terminology
---  https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf
---  - Seed = "Verb: To acquire bits with sufficient entropy for the desired security strength.
---    These bits will be used as input to a DRBG mechanism to determine a portion of the initial internal state."
---  - Reseed = "Verb: To acquire additional bits that will affect the internal state of the DRBG mechanism."
-
--- NOTE: RNG' and PRNG' are almost, but not exactly, equivalent to System.Random and System.Random.Stateful
--- PRNG' and RandomGen are equivalent aside from split, and RNG' matches StatefulGen (and Botan.Low.RNG.RNG
--- also can be an instance of both RNG' and StatefulGen)
--- However, RNG' is explicitly IO (for better or worse), and / as it is intended to represent TRNGs
--- To counter, RNG' partly has an IO constraint because of Botan.Low.RNG.RNG, and I do
--- understand the use intent of the m in Stateful g m as it allows you to swap between
--- IO and ST (and MonadIO)
--- They could be aligned more completely a la `class RNG' gen m where` to match StatefulGen
--- but I'd also like to keep the implications of (T)RNG' vs PRNG', and especially with
--- CSPRNG' specifically implying 'a PRNG indistinguishable from (T)RNG'
--- LATER: We can keep the T implication if we "require" that the RNG pass tests for uniform
--- distribution; otherwise we should reduce RNG from True TRNG to one that is explicitly
--- Unknown URNG - a slightly more relaxed constraint than true entropy. Note that
--- it is *not* 'stateful', it could be true random, *we're not supposed to be able to tell*.
--- Both System.Random and System.Random.Stateful are still both quite explicitly about PRNG,
--- and they even state it everywhere. We want to disambiguate RNG-in-general from specifically
--- PRNG or TRNG.
--- MINOR NOTE: If we reduce RNG from TRNG to URNG, we should also acknowledge that true random
--- is unaffected by reseeding, and so that anything that can be reseeded is also at least URNG
--- if not PRNG. This is a question of chaos vs random - chaos can be affected / reseeded but
--- still not predicted.
-
--- RandomGenerator
-class RNG' gen where
-
-    -- generateRandomWord8 :: gen -> IO Word8
-    -- generateRandomWord16 :: gen -> IO Word16
-    -- generateRandomWord32 :: gen -> IO Word32
-    -- generateRandomWord64 :: gen -> IO Word64
-    -- generateRandomShortByteString :: gen -> IO ShortByteString
-
-    generateRandomBytes' :: Int -> gen -> IO ByteString
-
--- class RNG' gen => EntropyPool' gen where
-
-    addEntropyRNG' :: ByteString -> gen -> IO ()
-
-    -- Convenience
-
-    -- NOTE: Omitted:
-    -- addSystemEntropy' :: Int -> gen -> IO ()
-    -- addSystemEntropy' n = addRandomEntropy' n systemRNG'
-
-    addRandomEntropy'        :: (RNG' seed) => Int -> seed -> gen -> IO ()
-    addRandomEntropy' nbytes seed gen = do
-        entropy <- generateRandomBytes' nbytes seed
-        addEntropyRNG' entropy gen
-
-    addPseudoRandomEntropy'  :: (PRNG' seed) => Int -> seed -> gen -> IO seed
-    addPseudoRandomEntropy' nbytes seed gen = do
-        addEntropyRNG' entropy gen
-        return seed'
-        where
-            (entropy, seed') = generatePseudoRandomBytes' nbytes seed
-
-
--- PseudoRandomGenerator
--- NOTE: Where possible, prefer `gen -> (a, gen)` as with MonadState `s -> (a, s)`
-class PRNG' gen where
-
-    generatePseudoRandomBytes'   :: Int -> gen -> (ByteString, gen)
-
--- class PRNG' gen => Reseedable' gen where
-
-    reseedEntropy'               :: ByteString -> gen -> gen
-
-    -- Convenience
-
-    -- NOTE: Omitted:
-    -- reseedSystem'                :: Int -> gen -> IO gen
-    -- reseedSystem' n = reseedRandom' n systemRNG'
-
-    reseedRandom'                :: (RNG' seed) => Int -> seed -> gen -> IO gen
-    reseedRandom' nbytes seed gen = do
-        entropy <- generateRandomBytes' nbytes seed
-        return (reseedEntropy' entropy gen)
-
-    reseedPseudoRandom'          :: (PRNG' seed) => Int -> seed -> gen -> (seed, gen)
-    reseedPseudoRandom' nbytes seed gen = (seed', gen') where
-        (entropy, seed') = generatePseudoRandomBytes' nbytes seed
-        gen'             = reseedEntropy' entropy gen
-
--- AsRandomGenerator
-newtype CSPRNG' gen
-    = MkCSPRNG'
-    -- { runCSPRNG' :: PRNG' gen => MVar gen
-    { runCSPRNG' :: MVar gen
-    }
-
-modifyCSPRNG' :: CSPRNG' gen -> (gen -> IO (gen, a)) -> IO a
-modifyCSPRNG' (MkCSPRNG' mgen) = modifyMVar mgen
-
-modifyCSPRNG_' :: CSPRNG' gen -> (gen -> IO gen) -> IO ()
-modifyCSPRNG_' (MkCSPRNG' mgen) = modifyMVar_ mgen
-
-instance (PRNG' gen) => RNG' (CSPRNG' gen) where
-
-    generateRandomBytes' :: Int -> CSPRNG' gen -> IO ByteString
-    generateRandomBytes' nbytes csprng = modifyCSPRNG' csprng $ \ gen -> do
-        return $ swap $ generatePseudoRandomBytes' nbytes gen
-
-    addEntropyRNG' :: ByteString -> CSPRNG' gen -> IO ()
-    addEntropyRNG' entropy csprng = modifyCSPRNG_' csprng $ \ gen -> do
-        return (reseedEntropy' entropy gen)
-
--- NOTE: System.Random.Stateful uses a typeclass to represent 'frozen' PRNG
--- with an associated data type pointing back to the original.
--- Notably, it uses fundeps in the associated type,
-{-
-class StatefulGen (MutableGen f m) m => FrozenGen f m where
-    type MutableGen f m = (g :: Type) | g -> f
-    freezeGen :: MutableGen f m -> m f
-    thawGen :: f -> m (MutableGen f m)
--}
-
-class PRNG' gen => Seedable' gen where
-
-    type Seed' gen
-
-    -- Seed the state of an existing generator
-    seed :: Seed' gen -> gen -> gen
-
-    freezeSeed :: gen -> Seed' gen
-
-    thawSeed :: Seed' gen -> gen
-
--- TODO: NIST DRBG standards
---  https://github.com/ANSSI-FR/libdrbg
---  https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf
--- The three NIST SP 800-90A DRBG mechanisms
--- NOTE: NIST terminology:
---  - DRGB = Deterministic Random Bit Generator = PRNG
---  - NRGB = Non-deterministic Random Bit Generator = (True) RNG
-{-
-data HashType
-data BlockCipherType
-
-data HashDerivationFunction
-
-data HashDRBG = MkHashDRBG
-    { hashDRBGValue     :: ByteString       -- ^ v
-    , hashDRBGConstant  :: ByteString       -- ^ c
-    -- Administrative
-    , hashDRBGSeedLen               :: Int  -- ^ seedlen
-    , hashDRBGSecurityStrength      :: Int  -- ^ security_strength
-    , hashDRBGPredictionResistant   :: Bool -- ^ prediction_resistance_flag
-    }
-
-hashDRBGInstantiate :: Int -> Bool -> ByteString -> HashDRBG
-hashDRBGInstantiate requestedStrength predictionResistant personalizationString = undefined
--}

--- a/botan/src/Botan/Utility.hs
+++ b/botan/src/Botan/Utility.hs
@@ -1,33 +1,30 @@
-module Botan.Utility
-( constantTimeCompare
-, scrubMemory
-, scrub
-, scrubArray
-, scrubForeignPtr
-, scrubForeignPtrArray
-, scrubByteString
-, HexCase(..)
-, hexEncode
-, hexDecode
-, base64Encode
-, base64Decode
-) where
+module Botan.Utility (
+    constantTimeCompare
+  , scrubMemory
+  , scrub
+  , scrubArray
+  , scrubForeignPtr
+  , scrubForeignPtrArray
+  , scrubByteString
+  , HexCase(..)
+  , hexEncode
+  , hexDecode
+  , base64Encode
+  , base64Decode
+  ) where
 
 import           System.IO.Unsafe
 
 import           Data.ByteString.Internal as ByteString
 import           Data.ByteString.Unsafe as ByteString
 
-import qualified Botan.Bindings.Utility as Bindings
-import           Botan.Low.Utility (HexEncodingFlags (..), pattern HexLowerCase,
-                     pattern HexUpperCase)
+import           Botan.Low.Utility (HexEncodingFlags)
 import qualified Botan.Low.Utility as Low
 
 import           Foreign.ForeignPtr
 import           Foreign.Ptr
 import           Foreign.Storable
 
-import           Botan.Error
 import           Botan.Prelude
 
 -- | Returns 0 if x[0..len] == y[0..len], -1 otherwise.
@@ -39,16 +36,16 @@ constantTimeCompare = unsafePerformIO3 Low.constantTimeCompare
 scrubMemory :: (MonadIO m) => Ptr a -> Int -> m ()
 scrubMemory ptr sz = liftIO $ Low.scrubMem ptr sz
 
-scrub :: (MonadIO m, Storable a) => Ptr a -> m ()
+scrub :: MonadIO m => Ptr a -> m ()
 scrub ptr = scrubMemory ptr (sizeOf ptr)
 
-scrubArray :: (MonadIO m, Storable a) => Int -> Ptr a -> m ()
+scrubArray :: MonadIO m => Int -> Ptr a -> m ()
 scrubArray n ptr  = scrubMemory ptr (n * sizeOf ptr)
 
-scrubForeignPtr :: (MonadIO m, Storable a) => ForeignPtr a -> m ()
+scrubForeignPtr :: MonadIO m => ForeignPtr a -> m ()
 scrubForeignPtr fptr = liftIO $ withForeignPtr fptr scrub
 
-scrubForeignPtrArray :: (MonadIO m, Storable a) => Int -> ForeignPtr a -> m ()
+scrubForeignPtrArray :: MonadIO m => Int -> ForeignPtr a -> m ()
 scrubForeignPtrArray n fptr = liftIO $ withForeignPtr fptr (scrubArray n)
 
 -- TODO: Rename scrubByteStringImmediately?

--- a/botan/src/Botan/Version.hs
+++ b/botan/src/Botan/Version.hs
@@ -1,12 +1,12 @@
-module Botan.Version
-( botanFFIAPIVersion
-, botanFFISupportsAPI
-, botanVersionText
-, botanVersionMajor
-, botanVersionMinor
-, botanVersionPatch
-, botanVersionDatestamp
-) where
+module Botan.Version (
+    botanFFIAPIVersion
+  , botanFFISupportsAPI
+  , botanVersionText
+  , botanVersionMajor
+  , botanVersionMinor
+  , botanVersionPatch
+  , botanVersionDatestamp
+  ) where
 
 import           System.IO.Unsafe
 

--- a/botan/src/Botan/X509.hs
+++ b/botan/src/Botan/X509.hs
@@ -1,8 +1,17 @@
-module Botan.X509 where
+module Botan.X509 (
+    DistinguishedName (..)
+  , fromDN
+  , toDN
+  , KeyConstraint (..)
+  , allKeyConstraints
+  , allConstraints
+  , X509VerifyStatusCode
+  , X509CertificateAuthority
+  , X509CertificateStore
+  , X509CRL
+  ) where
 
 import           Botan.Prelude
-
-import           Data.Bits
 
 import qualified Botan.Low.X509 as Low
 import           Data.List (nub)
@@ -53,7 +62,7 @@ data KeyConstraint
     | EncipherOnly
     | DecipherOnly
     | KeyConstraints [KeyConstraint]
-    deriving (Eq)
+    deriving stock (Eq)
 
 allKeyConstraints :: [KeyConstraint]
 allKeyConstraints =
@@ -112,6 +121,7 @@ instance (Enum KeyConstraint) where
     fromEnum EncipherOnly               = fromIntegral Low.EncipherOnly     -- 256
     fromEnum DecipherOnly               = fromIntegral Low.DecipherOnly     -- 128
     fromEnum (KeyConstraints (kc:kcs))  = fromEnum kc .|. fromEnum (KeyConstraints kcs)
+    fromEnum _                          = error "fromEnum: KeyConstraint"
 
 -- TODO: https://x509errors.org/
 data X509VerifyStatusCode

--- a/botan/src/Botan/ZFEC.hs
+++ b/botan/src/Botan/ZFEC.hs
@@ -1,6 +1,9 @@
-module Botan.ZFEC where
+module Botan.ZFEC (
+    zfecEncode
+  , zfecDecode
+  ) where
 
-import           Botan.Low.ZFEC (ZFECShare (..))
+import           Botan.Low.ZFEC (ZFECShare)
 import qualified Botan.Low.ZFEC as Low
 
 import           Botan.Prelude


### PR DESCRIPTION
When fixing the warnings, we've tried for the most part not to change the definitions and implementations of types, classes and functions. The exported entities should still be the same. With respect to unused definitions, we have mostly removed them. Even if some unused definitions could have been integrated into existing code or exported directly, we did not do such investigations for the sake of saving time.