### PR TITLE
Fix a segfault in `blockCipherEncryptBlocks` and `blockCipherDecryptBlocks`

### DIFF
--- a/botan-low/CHANGELOG.md
+++ b/botan-low/CHANGELOG.md
@@ -37,6 +37,8 @@
 * NON-BREAKING: in the `BlockCipher` module, add new pattern synonyms `Lion` and
   `Cascade` and accompanying utility functions `lion` and `cascade` for the
   "Lion" and "Cascade" ciphers respectively.
+* PATCH: fix an "address out of bounds" bug in `blockCipherEncryptBlocks` and
+  `blockCipherDecryptBlocks` that occasionally caused segfaults.
 
 ## 0.0.2.0 -- 2025-09-17
 

--- a/botan-low/botan-low.cabal
+++ b/botan-low/botan-low.cabal
@@ -142,7 +142,6 @@ test-suite test
     , bytestring
     , containers
     , hspec
-    , QuickCheck
     , tasty
     , tasty-hspec
     , tasty-hunit
@@ -152,7 +151,7 @@ test-suite test
     Test.Botan.Low.PwdHash
     Test.Botan.Low.SRP6
     Test.Botan.Low.SRP6.Example
-    Test.Prelude
+    Test.Util.HSpec
 
 --
 -- Unit tests

--- a/botan-low/test/Test/Botan/Low/PwdHash.hs
+++ b/botan-low/test/Test/Botan/Low/PwdHash.hs
@@ -11,11 +11,13 @@ import           Botan.Low.Hash
 import           Botan.Low.MAC
 import           Botan.Low.PwdHash
 import           Control.Exception
+import           Control.Monad
 import           Data.ByteString
-import           Test.Prelude
+import           Test.Hspec
 import           Test.Tasty
 import           Test.Tasty.Hspec
 import           Test.Tasty.HUnit
+import           Test.Util.HSpec
 
 tests :: IO TestTree
 tests = do
@@ -137,6 +139,10 @@ test_pwdhash_badSchemeName useTimed = do
           void $ pwdhashTimed schemeName 200 64 passphrase salt
       | otherwise = try $
           void $ pwdhash schemeName 1 0 0 64 passphrase salt
+
+{-------------------------------------------------------------------------------
+  Specs
+-------------------------------------------------------------------------------}
 
 -- | Run 'pwdhash' and 'pwdhashTimed', and check that their outputs match.
 spec_pwdhash :: Spec

--- a/botan-low/test/Test/Botan/Low/SRP6.hs
+++ b/botan-low/test/Test/Botan/Low/SRP6.hs
@@ -9,9 +9,10 @@ import           Botan.Low.PubKey
 import           Botan.Low.RNG
 import           Botan.Low.SRP6
 import           Data.ByteString
-import           Test.Prelude
+import           Test.Hspec
 import           Test.Tasty
 import           Test.Tasty.Hspec
+import           Test.Util.HSpec
 
 tests :: IO TestTree
 tests = do

--- a/botan-low/test/Test/Prelude.hs
+++ b/botan-low/test/Test/Prelude.hs
@@ -14,18 +14,15 @@ module Test.Prelude (
   , anyBotanException
   ) where
 
-import           Prelude
-
-import           Test.Hspec
-import           Test.QuickCheck
-
+import           Botan.Low.Error
+import           Control.Exception
 import           Control.Monad
-
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Char8
-
-import           Botan.Low.Error
+import           Prelude
+import           Test.Hspec
+import           Test.QuickCheck
 
 chars :: ByteString -> [Char]
 chars = Char8.unpack

--- a/botan-low/test/Test/Util/HSpec.hs
+++ b/botan-low/test/Test/Util/HSpec.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Util.HSpec (
+    testSuite
+  , chars
+  , pass
+  ) where
+
+import           Control.Monad
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BSC
+import           Test.Hspec
+
+testSuite :: [t] -> (t -> String) -> (t -> SpecWith a) -> SpecWith a
+testSuite tests testName runTest = forM_ tests $ \ test -> describe (testName test) (runTest test)
+
+chars :: ByteString -> [Char]
+chars = BSC.unpack
+
+-- An alternative to void?
+--  _ <- performSomeAction
+--  pass
+pass :: (Monad m) => m ()
+pass = return ()


### PR DESCRIPTION
The encryption/decryption functions require an argument that specifies the number of blocks to encrypt/decrypt, but we were passing the number of *bytes* instead.