### PR TITLE
Fix a bug in public-key `encrypt` and `decrypt` functions

### DIFF
--- a/botan-low/CHANGELOG.md
+++ b/botan-low/CHANGELOG.md
@@ -39,6 +39,9 @@
   "Lion" and "Cascade" ciphers respectively.
 * PATCH: fix an "address out of bounds" bug in `blockCipherEncryptBlocks` and
   `blockCipherDecryptBlocks` that occasionally caused segfaults.
+* PATCH: fix an "insufficient buffer space" bug in
+  `Botan.Low.PubKey.Encrypt.encrypt` and `Botan.Low.PubKey.Decrypt.decrypt`. See
+  PR [#79](https://github.com/haskell-cryptography/botan/pull/79).
 
 ## 0.0.2.0 -- 2025-09-17
 

--- a/botan-low/test/Test/Botan/Low/PubKey/Decrypt.hs
+++ b/botan-low/test/Test/Botan/Low/PubKey/Decrypt.hs
@@ -18,15 +18,12 @@ tests = do
     specs <- testSpec "spec_decrypt" spec_decrypt
     pure $ testGroup "Test.Botan.Low.PubKey.Decrypt" [
         specs
-        -- TODO: temporarily disabled because the test suite fails. See issue
-        -- #33.
-      | False
       ]
 
 pks :: [(ByteString, ByteString, ByteString)]
 pks =
     [ ("RSA", "2048", "PKCS1v15")
-    , ("SM2", "sm2p256v1", "SHA-256") -- NOTE: Decrypt fails with InsufficientBufferSpace
+    , ("SM2", "sm2p256v1", "SHA-256") -- NOTE: SM2 takes a hash rather than a padding
     , ("ElGamal", "modp/ietf/1024", "PKCS1v15")
     ]
 

--- a/botan-low/test/Test/Botan/Low/PubKey/Encrypt.hs
+++ b/botan-low/test/Test/Botan/Low/PubKey/Encrypt.hs
@@ -17,13 +17,7 @@ tests = do
     specs <- testSpec "spec_encrypt" spec_encrypt
     pure $ testGroup "Test.Botan.Low.PubKey.Encrypt" [
         specs
-        -- TODO: temporarily disabled because the test suite fails. See issue
-        -- #33.
-      | False
       ]
-
--- NOTE: SM2 encrypt fails with InsufficientBufferSpace unless sm2p256v1 is used as the
---  curve when creating the key (but creating the key and the encryption context do not fail)
 
 pks :: [(ByteString, ByteString, ByteString)]
 pks =


### PR DESCRIPTION
This resolves a part of #33. See the commit message for more information.