### PR TITLE
Fix `PubKey.DSA` tests

### DIFF
--- a/botan-low/test/Test/Botan/Low/PubKey/DSA.hs
+++ b/botan-low/test/Test/Botan/Low/PubKey/DSA.hs
@@ -18,34 +18,12 @@ tests = do
     specs <- testSpec "spec_dsa" spec_dsa
     pure $ testGroup "Test.Botan.Low.PubKey.DSA" [
         specs
-        -- TODO: temporarily disabled because the test suite fails. See issue
-        -- #33.
-      | False
       ]
 
 -- TODO: Consolidate
 dlGroups :: [ByteString]
 dlGroups =
-    [ "ffdhe/ietf/2048"
-    , "ffdhe/ietf/3072"
-    , "ffdhe/ietf/4096"
-    , "ffdhe/ietf/6144"
-    , "ffdhe/ietf/8192"
-    , "modp/ietf/1024"
-    , "modp/ietf/1536"
-    , "modp/ietf/2048"
-    , "modp/ietf/3072"
-    , "modp/ietf/4096"
-    , "modp/ietf/6144"
-    , "modp/ietf/8192"
-    , "modp/srp/1024"
-    , "modp/srp/1536"
-    , "modp/srp/2048"
-    , "modp/srp/3072"
-    , "modp/srp/4096"
-    , "modp/srp/6144"
-    , "modp/srp/8192"
-    , "dsa/jce/1024"
+    [ "dsa/jce/1024"
     , "dsa/botan/2048"
     , "dsa/botan/3072"
     ]
@@ -73,7 +51,7 @@ spec_dsa :: Spec
 spec_dsa = testSuite dlGroups chars $ \ dlGroup -> do
     it "privKeyLoadDSA" $ do
         rng <- rngInit "system"
-        privKey <- privKeyCreate "DH" dlGroup rng
+        privKey <- privKeyCreate "DSA" dlGroup rng
         p <- privKeyField privKey "p"
         q <- privKeyField privKey "q"
         g <- privKeyField privKey "g"
@@ -82,7 +60,7 @@ spec_dsa = testSuite dlGroups chars $ \ dlGroup -> do
         pass
     it "pubKeyLoadDSA" $ do
         rng <- rngInit "system"
-        privKey <- privKeyCreate "DH" dlGroup rng
+        privKey <- privKeyCreate "DSA" dlGroup rng
         pubKey <- privKeyExportPubKey privKey
         p <- pubKeyField pubKey "p"
         q <- pubKeyField pubKey "q"


### PR DESCRIPTION
We were testing with a bunch of `DL_Group`s that were not suitable for `DSA`, see https://botan.randombit.net/handbook/api_ref/pubkey.html#dl-group.