### PR TITLE
Fix an "insufficient buffer space" bug in `Botan.Low.Cipher.cipherUpdate`

### DIFF
--- a/botan-low/CHANGELOG.md
+++ b/botan-low/CHANGELOG.md
@@ -42,6 +42,9 @@
 * PATCH: fix an "insufficient buffer space" bug in
   `Botan.Low.PubKey.Encrypt.encrypt` and `Botan.Low.PubKey.Decrypt.decrypt`. See
   PR [#79](https://github.com/haskell-cryptography/botan/pull/79).
+* PATCH: Fix an "insufficient buffer space" bug in
+  `Botan.Low.Cipher.cipherUpdate`. See PR
+  [#84](https://github.com/haskell-cryptography/botan/pull/84)
 
 ## 0.0.2.0 -- 2025-09-17
 


### PR DESCRIPTION
If the final update is performed and the output buffer is too small, we now retry with the proper output buffer size.