### PR TITLE
Enable `DuplicateRecordFields`, `NoFieldSelectors`, and `OverloadedRecordDot`

### DIFF
--- a/botan-bindings/CHANGELOG.md
+++ b/botan-bindings/CHANGELOG.md
@@ -32,6 +32,10 @@
   "Cascade" ciphers respectively.
 * PATCH: restrict the version of the C++ library to `<4`. See PR
   [#103](https://github.com/haskell-cryptography/botan/pull/103).
+* BREAKING: enable `NoFieldSelectors`. See PR
+  [#106](https://github.com/haskell-cryptography/botan/pull/106). As a result,
+  this package no longer exports field selectors for datatypes defined in the
+  package.
 
 ## 0.1.0.0 -- 2025-09-17
 

--- a/botan-bindings/botan-bindings.cabal
+++ b/botan-bindings/botan-bindings.cabal
@@ -64,8 +64,10 @@ common language
   default-language: GHC2021
   default-extensions:
     DerivingStrategies
+    DuplicateRecordFields
+    NoFieldSelectors
+    OverloadedRecordDot
     PatternSynonyms
-    RecordWildCards
     RoleAnnotations
 
 library

--- a/botan-low/CHANGELOG.md
+++ b/botan-low/CHANGELOG.md
@@ -67,14 +67,19 @@
   - `CheckKeyFlags`
   - `PrivKeyExportFlags`
   - `HexEncodingFlags`
-- BREAKING: remove the `botan-low-bench` benchmark. See PR [#98]
-- PATCH: fix a bug where some functions returning a `Bool` were returning
+* BREAKING: remove the `botan-low-bench` benchmark. See PR
+  [#98](https://github.com/haskell-cryptography/botan/pull/98).
+* PATCH: fix a bug where some functions returning a `Bool` were returning
   `False` instead of throwing an exception and vice versa. See PR
   [#105](https://github.com/haskell-cryptography/botan/pull/105). These functions
   are:
   - `pubKeyCheckKey`
   - `x509CertHostnameMatch`
   - `x509IsRevoked`
+* BREAKING: enable `NoFieldSelectors`. See PR
+  [#106](https://github.com/haskell-cryptography/botan/pull/106). As a result,
+  this package no longer exports field selectors for datatypes defined in the
+  package.
 
 ## 0.0.2.0 -- 2025-09-17
 

--- a/botan-low/botan-low.cabal
+++ b/botan-low/botan-low.cabal
@@ -70,9 +70,11 @@ common language
   default-language: GHC2021
   default-extensions:
     DerivingStrategies
+    DuplicateRecordFields
     LambdaCase
+    NoFieldSelectors
+    OverloadedRecordDot
     PatternSynonyms
-    RecordWildCards
     RoleAnnotations
     ViewPatterns
 

--- a/botan-low/src/Botan/Low/BlockCipher.hs
+++ b/botan-low/src/Botan/Low/BlockCipher.hs
@@ -197,8 +197,8 @@ blockCipherDestroy  :: BlockCipher -> IO ()
 createBlockCipher   :: (Ptr BotanBlockCipher -> IO CInt) -> IO BlockCipher
 (withBlockCipher, blockCipherDestroy, createBlockCipher)
     = mkBindings
-        MkBotanBlockCipher runBotanBlockCipher
-        MkBlockCipher getBlockCipherForeignPtr
+        MkBotanBlockCipher (.runBotanBlockCipher)
+        MkBlockCipher (.getBlockCipherForeignPtr)
         botan_block_cipher_destroy
 
 

--- a/botan-low/src/Botan/Low/Cipher.hs
+++ b/botan-low/src/Botan/Low/Cipher.hs
@@ -203,8 +203,8 @@ cipherDestroy  :: Cipher -> IO ()
 createCipher   :: (Ptr BotanCipher -> IO CInt) -> IO Cipher
 (withCipher, cipherDestroy, createCipher)
     = mkBindings
-        MkBotanCipher runBotanCipher
-        MkCipher getCipherForeignPtr
+        MkBotanCipher (.runBotanCipher)
+        MkCipher (.getCipherForeignPtr)
         botan_cipher_destroy
 
 type CipherNonce = ByteString

--- a/botan-low/src/Botan/Low/Error/Internal.hs
+++ b/botan-low/src/Botan/Low/Error/Internal.hs
@@ -73,7 +73,7 @@ newtype BotanErrorCode = BotanErrorCode CInt
 botanErrorDescription :: BotanErrorCode -> IO ByteString
 botanErrorDescription (BotanErrorCode e) = do
     descPtr <- botan_error_description e
-    peekCString (unConstPtr descPtr)
+    peekCString descPtr.unConstPtr
 
 newtype BotanErrorMessage = BotanErrorMessage ByteString
   deriving newtype Show
@@ -84,7 +84,7 @@ newtype BotanErrorMessage = BotanErrorMessage ByteString
 botanErrorLastExceptionMessage :: IO BotanErrorMessage
 botanErrorLastExceptionMessage = do
     msgPtr <- botan_error_last_exception_message
-    BotanErrorMessage <$> peekCString (unConstPtr msgPtr)
+    BotanErrorMessage <$> peekCString msgPtr.unConstPtr
 
 {-------------------------------------------------------------------------------
   Exception hierarchy

--- a/botan-low/src/Botan/Low/FPE.hs
+++ b/botan-low/src/Botan/Low/FPE.hs
@@ -80,8 +80,8 @@ fpeDestroy  :: FPE -> IO ()
 createFPE   :: (Ptr BotanFPE -> IO CInt) -> IO FPE
 (withFPE, fpeDestroy, createFPE)
     = mkBindings
-        MkBotanFPE runBotanFPE
-        MkFPE getFPEForeignPtr
+        MkBotanFPE (.runBotanFPE)
+        MkFPE (.getFPEForeignPtr)
         botan_fpe_destroy
 
 data FPEFlags =

--- a/botan-low/src/Botan/Low/HOTP.hs
+++ b/botan-low/src/Botan/Low/HOTP.hs
@@ -173,8 +173,8 @@ hotpDestroy  :: HOTP -> IO ()
 createHOTP   :: (Ptr BotanHOTP -> IO CInt) -> IO HOTP
 (withHOTP, hotpDestroy, createHOTP)
     = mkBindings
-        MkBotanHOTP runBotanHOTP
-        MkHOTP getHOTPForeignPtr
+        MkBotanHOTP (.runBotanHOTP)
+        MkHOTP (.getHOTPForeignPtr)
         botan_hotp_destroy
 
 type HOTPHashName = HashName

--- a/botan-low/src/Botan/Low/Hash.hs
+++ b/botan-low/src/Botan/Low/Hash.hs
@@ -146,8 +146,8 @@ hashDestroy  :: Hash -> IO ()
 createHash   :: (Ptr BotanHash -> IO CInt) -> IO Hash
 (withHash, hashDestroy, createHash)
     = mkBindings
-        MkBotanHash runBotanHash
-        MkHash getHashForeignPtr
+        MkBotanHash (.runBotanHash)
+        MkHash (.getHashForeignPtr)
         botan_hash_destroy
 
 type HashName = ByteString

--- a/botan-low/src/Botan/Low/MAC.hs
+++ b/botan-low/src/Botan/Low/MAC.hs
@@ -169,8 +169,8 @@ macDestroy  :: MAC -> IO ()
 createMAC   :: (Ptr BotanMAC -> IO CInt) -> IO MAC
 (withMAC, macDestroy, createMAC)
     = mkBindings
-        MkBotanMAC runBotanMAC
-        MkMAC getMACForeignPtr
+        MkBotanMAC (.runBotanMAC)
+        MkMAC (.getMACForeignPtr)
         botan_mac_destroy
 
 type MACName = ByteString

--- a/botan-low/src/Botan/Low/MPI.hs
+++ b/botan-low/src/Botan/Low/MPI.hs
@@ -92,8 +92,8 @@ mpDestroy  :: MP -> IO ()
 createMP   :: (Ptr BotanMP -> IO CInt) -> IO MP
 (withMP, mpDestroy, createMP)
     = mkBindings
-        MkBotanMP runBotanMP
-        MkMP getMPForeignPtr
+        MkBotanMP (.runBotanMP)
+        MkMP (.getMPForeignPtr)
         botan_mp_destroy
 
 mpInit :: IO MP

--- a/botan-low/src/Botan/Low/PubKey.hs
+++ b/botan-low/src/Botan/Low/PubKey.hs
@@ -288,8 +288,8 @@ privKeyDestroy  :: PrivKey -> IO ()
 createPrivKey   :: (Ptr BotanPrivKey -> IO CInt) -> IO PrivKey
 (withPrivKey, privKeyDestroy, createPrivKey)
     = mkBindings
-        MkBotanPrivKey runBotanPrivKey
-        MkPrivKey getPrivKeyForeignPtr
+        MkBotanPrivKey (.runBotanPrivKey)
+        MkPrivKey (.getPrivKeyForeignPtr)
         botan_privkey_destroy
 
 type PKName = ByteString
@@ -679,8 +679,8 @@ pubKeyDestroy  :: PubKey -> IO ()
 createPubKey   :: (Ptr BotanPubKey -> IO CInt) -> IO PubKey
 (withPubKey, pubKeyDestroy, createPubKey)
     = mkBindings
-        MkBotanPubKey runBotanPubKey
-        MkPubKey getPubKeyForeignPtr
+        MkBotanPubKey (.runBotanPubKey)
+        MkPubKey (.getPubKeyForeignPtr)
         botan_pubkey_destroy
 
 pubKeyLoad

--- a/botan-low/src/Botan/Low/PubKey/Decrypt.hs
+++ b/botan-low/src/Botan/Low/PubKey/Decrypt.hs
@@ -48,8 +48,8 @@ decryptDestroy  :: Decrypt -> IO ()
 createDecrypt   :: (Ptr BotanPKOpDecrypt -> IO CInt) -> IO Decrypt
 (withDecrypt, decryptDestroy, createDecrypt)
     = mkBindings
-        MkBotanPKOpDecrypt runBotanPKOpDecrypt
-        MkDecrypt getDecryptForeignPtr
+        MkBotanPKOpDecrypt (.runBotanPKOpDecrypt)
+        MkDecrypt (.getDecryptForeignPtr)
         botan_pk_op_decrypt_destroy
 
 decryptCreate

--- a/botan-low/src/Botan/Low/PubKey/Encrypt.hs
+++ b/botan-low/src/Botan/Low/PubKey/Encrypt.hs
@@ -49,8 +49,8 @@ encryptDestroy  :: Encrypt -> IO ()
 createEncrypt   :: (Ptr BotanPKOpEncrypt -> IO CInt) -> IO Encrypt
 (withEncrypt, encryptDestroy, createEncrypt)
     = mkBindings
-        MkBotanPKOpEncrypt runBotanPKOpEncrypt
-        MkEncrypt getEncryptForeignPtr
+        MkBotanPKOpEncrypt (.runBotanPKOpEncrypt)
+        MkEncrypt (.getEncryptForeignPtr)
         botan_pk_op_encrypt_destroy
 
 encryptCreate

--- a/botan-low/src/Botan/Low/PubKey/KeyAgreement.hs
+++ b/botan-low/src/Botan/Low/PubKey/KeyAgreement.hs
@@ -122,8 +122,8 @@ keyAgreementDestroy  :: KeyAgreement -> IO ()
 createKeyAgreement   :: (Ptr BotanPKOpKeyAgreement -> IO CInt) -> IO KeyAgreement
 (withKeyAgreement, keyAgreementDestroy, createKeyAgreement)
     = mkBindings
-        MkBotanPKOpKeyAgreement runBotanPKOpKeyAgreement
-        MkKeyAgreement getKeyAgreementForeignPtr
+        MkBotanPKOpKeyAgreement (.runBotanPKOpKeyAgreement)
+        MkKeyAgreement (.getKeyAgreementForeignPtr)
         botan_pk_op_key_agreement_destroy
 
 -- NOTE: Silently uses the system RNG

--- a/botan-low/src/Botan/Low/PubKey/KeyEncapsulation.hs
+++ b/botan-low/src/Botan/Low/PubKey/KeyEncapsulation.hs
@@ -127,8 +127,8 @@ kemEncryptDestroy  :: KEMEncrypt -> IO ()
 createKEMEncrypt   :: (Ptr BotanPKOpKEMEncrypt -> IO CInt) -> IO KEMEncrypt
 (withKEMEncrypt, kemEncryptDestroy, createKEMEncrypt)
     = mkBindings
-        MkBotanPKOpKEMEncrypt runBotanPKOpKEMEncrypt
-        MkKEMEncrypt getKEMEncryptForeignPtr
+        MkBotanPKOpKEMEncrypt (.runBotanPKOpKEMEncrypt)
+        MkKEMEncrypt (.getKEMEncryptForeignPtr)
         botan_pk_op_kem_encrypt_destroy
 
 
@@ -198,8 +198,8 @@ kemDecryptDestroy  :: KEMDecrypt -> IO ()
 createKEMDecrypt   :: (Ptr BotanPKOpKEMDecrypt -> IO CInt) -> IO KEMDecrypt
 (withKEMDecrypt, kemDecryptDestroy, createKEMDecrypt)
     = mkBindings
-        MkBotanPKOpKEMDecrypt runBotanPKOpKEMDecrypt
-        MkKEMDecrypt getKEMDecryptForeignPtr
+        MkBotanPKOpKEMDecrypt (.runBotanPKOpKEMDecrypt)
+        MkKEMDecrypt (.getKEMDecryptForeignPtr)
         botan_pk_op_kem_decrypt_destroy
 
 kemDecryptCreate

--- a/botan-low/src/Botan/Low/PubKey/Sign.hs
+++ b/botan-low/src/Botan/Low/PubKey/Sign.hs
@@ -54,8 +54,8 @@ signDestroy  :: Sign -> IO ()
 createSign   :: (Ptr BotanPKOpSign -> IO CInt) -> IO Sign
 (withSign, signDestroy, createSign)
     = mkBindings
-        MkBotanPKOpSign runBotanPKOpSign
-        MkSign getSignForeignPtr
+        MkBotanPKOpSign (.runBotanPKOpSign)
+        MkSign (.getSignForeignPtr)
         botan_pk_op_sign_destroy
 
 type SigningFlags = Word32

--- a/botan-low/src/Botan/Low/PubKey/Verify.hs
+++ b/botan-low/src/Botan/Low/PubKey/Verify.hs
@@ -44,8 +44,8 @@ verifyDestroy  :: Verify -> IO ()
 createVerify   :: (Ptr BotanPKOpVerify -> IO CInt) -> IO Verify
 (withVerify, verifyDestroy, createVerify)
     = mkBindings
-        MkBotanPKOpVerify runBotanPKOpVerify
-        MkVerify getVerifyForeignPtr
+        MkBotanPKOpVerify (.runBotanPKOpVerify)
+        MkVerify (.getVerifyForeignPtr)
         botan_pk_op_verify_destroy
 
 verifyCreate

--- a/botan-low/src/Botan/Low/RNG.hs
+++ b/botan-low/src/Botan/Low/RNG.hs
@@ -97,7 +97,7 @@ withRNG     :: RNG -> (BotanRNG -> IO a) -> IO a
 rngDestroy  :: RNG -> IO ()
 createRNG   :: (Ptr BotanRNG -> IO CInt) -> IO RNG
 (withRNG, rngDestroy, createRNG)
-    = mkBindings MkBotanRNG runBotanRNG MkRNG getRNGForeignPtr botan_rng_destroy
+    = mkBindings MkBotanRNG (.runBotanRNG) MkRNG (.getRNGForeignPtr) botan_rng_destroy
 
 type RNGType = ByteString
 

--- a/botan-low/src/Botan/Low/SRP6.hs
+++ b/botan-low/src/Botan/Low/SRP6.hs
@@ -284,8 +284,8 @@ srp6ServerSessionDestroy  :: SRP6ServerSession -> IO ()
 createSRP6ServerSession   :: (Ptr BotanSRP6ServerSession -> IO CInt) -> IO SRP6ServerSession
 (withSRP6ServerSession, srp6ServerSessionDestroy, createSRP6ServerSession)
     = mkBindings
-        MkBotanSRP6ServerSession runBotanSRP6ServerSession
-        MkSRP6ServerSession getSRP6ServerSessionForeignPtr
+        MkBotanSRP6ServerSession (.runBotanSRP6ServerSession)
+        MkSRP6ServerSession (.getSRP6ServerSessionForeignPtr)
         botan_srp6_server_session_destroy
 
 -- | Initialize an SRP-6 server session object

--- a/botan-low/src/Botan/Low/TOTP.hs
+++ b/botan-low/src/Botan/Low/TOTP.hs
@@ -167,8 +167,8 @@ totpDestroy  :: TOTP -> IO ()
 createTOTP   :: (Ptr BotanTOTP -> IO CInt) -> IO TOTP
 (withTOTP, totpDestroy, createTOTP)
     = mkBindings
-        MkBotanTOTP runBotanTOTP
-        MkTOTP getTOTPForeignPtr
+        MkBotanTOTP (.runBotanTOTP)
+        MkTOTP (.getTOTPForeignPtr)
         botan_totp_destroy
 
 type TOTPHashName = HashName

--- a/botan-low/src/Botan/Low/Version.hs
+++ b/botan-low/src/Botan/Low/Version.hs
@@ -45,7 +45,7 @@ botanFFISupportsAPI version = do
     throwBotanCatchingInvalidInput $ botan_ffi_supports_api (fromIntegral version)
 
 botanVersionString :: IO ByteString
-botanVersionString = botan_version_string >>= peekCString . unConstPtr
+botanVersionString = botan_version_string >>= peekCString . (.unConstPtr)
 
 -- | Returns the major version of the library
 botanVersionMajor :: IO Int

--- a/botan-low/src/Botan/Low/X509.hs
+++ b/botan-low/src/Botan/Low/X509.hs
@@ -111,7 +111,7 @@ withX509Cert     :: X509Cert -> (BotanX509Cert -> IO a) -> IO a
 x509CertDestroy  :: X509Cert -> IO ()
 createX509Cert   :: (Ptr BotanX509Cert -> IO CInt) -> IO X509Cert
 (withX509Cert, x509CertDestroy, createX509Cert)
-    = mkBindings MkBotanX509Cert runBotanX509Cert MkX509Cert getX509CertForeignPtr botan_x509_cert_destroy
+    = mkBindings MkBotanX509Cert (.runBotanX509Cert) MkX509Cert (.getX509CertForeignPtr) botan_x509_cert_destroy
 
 x509CertLoad
     :: ByteString   -- ^ __cert[]__
@@ -357,7 +357,7 @@ x509CertValidationStatus code = do
     status <- botan_x509_cert_validation_status (fromIntegral code)
     if status == ConstPtr nullPtr
         then return Nothing
-        else Just <$> packCString (unConstPtr status)
+        else Just <$> packCString status.unConstPtr
 
 -- /*
 -- * X.509 CRL
@@ -371,7 +371,7 @@ withX509CRL     :: X509CRL -> (BotanX509CRL -> IO a) -> IO a
 x509CRLDestroy  :: X509CRL -> IO ()
 createX509CRL   :: (Ptr BotanX509CRL -> IO CInt) -> IO X509CRL
 (withX509CRL, x509CRLDestroy, createX509CRL)
-    = mkBindings MkBotanX509CRL runBotanX509CRL MkX509CRL getX509CRLForeignPtr botan_x509_crl_destroy
+    = mkBindings MkBotanX509CRL (.runBotanX509CRL) MkX509CRL (.getX509CRLForeignPtr) botan_x509_crl_destroy
 
 x509CRLLoad
     :: ByteString   -- ^ __crl_bits[]__

--- a/botan/botan.cabal
+++ b/botan/botan.cabal
@@ -69,8 +69,10 @@ common language
   default-language: GHC2021
   default-extensions:
     DerivingStrategies
+    DuplicateRecordFields
+    NoFieldSelectors
+    OverloadedRecordDot
     PatternSynonyms
-    RecordWildCards
     RoleAnnotations
 
 library

--- a/botan/src/Botan/BlockCipher.hs
+++ b/botan/src/Botan/BlockCipher.hs
@@ -243,10 +243,10 @@ isBlockCipher128 :: BlockCipher -> Bool
 isBlockCipher128 = isJust . blockCipher128
 
 blockCipher128Name :: BlockCipher128 -> Low.BlockCipherName
-blockCipher128Name = blockCipherName . unBlockCipher128
+blockCipher128Name = blockCipherName . (.unBlockCipher128)
 
 blockCipher128KeySpec :: BlockCipher128 -> BlockCipherKeySpec
-blockCipher128KeySpec = blockCipherKeySpec . unBlockCipher128
+blockCipher128KeySpec = blockCipherKeySpec . (.unBlockCipher128)
 
 -- Associated types
 
@@ -436,7 +436,7 @@ data MutableBlockCipher = MkMutableBlockCipher
 -- Destructor
 
 destroyBlockCipher :: (MonadIO m) => MutableBlockCipher -> m ()
-destroyBlockCipher = liftIO . Low.blockCipherDestroy . mutableBlockCipherCtx
+destroyBlockCipher = liftIO . Low.blockCipherDestroy . (.mutableBlockCipherCtx)
 
 -- Initializers
 
@@ -454,20 +454,20 @@ getBlockCipherName
     :: (MonadIO m)
     => MutableBlockCipher   -- ^ The cipher object
     -> m (Low.BlockCipherName)  -- ^ The cipher name
-getBlockCipherName = liftIO . Low.blockCipherName . mutableBlockCipherCtx
+getBlockCipherName = liftIO . Low.blockCipherName . (.mutableBlockCipherCtx)
 
 getBlockCipherBlockSize
     :: (MonadIO m)
     => MutableBlockCipher  -- ^ The cipher object
     -> m Int
-getBlockCipherBlockSize = liftIO . Low.blockCipherBlockSize . mutableBlockCipherCtx
+getBlockCipherBlockSize = liftIO . Low.blockCipherBlockSize . (.mutableBlockCipherCtx)
 
 getBlockCipherKeySpec
     :: (MonadIO m)
     => MutableBlockCipher  -- ^ The cipher object
     -> m BlockCipherKeySpec
 getBlockCipherKeySpec mc = do
-    (mn,mx,md) <- liftIO $ Low.blockCipherGetKeyspec (mutableBlockCipherCtx mc)
+    (mn,mx,md) <- liftIO $ Low.blockCipherGetKeyspec mc.mutableBlockCipherCtx
     return $ keySpec mn mx md
 
 setBlockCipherKey
@@ -479,14 +479,14 @@ setBlockCipherKey k mc = do
     valid <- keySizeIsValid (ByteString.length k) <$> getBlockCipherKeySpec mc
     if valid
     then do
-        liftIO $ Low.blockCipherSetKey (mutableBlockCipherCtx mc) k
+        liftIO $ Low.blockCipherSetKey mc.mutableBlockCipherCtx k
         return True
     else return False
 
 -- Accessory functions
 
 clearBlockCipher :: (MonadIO m) => MutableBlockCipher -> m ()
-clearBlockCipher = liftIO . Low.blockCipherClear . mutableBlockCipherCtx
+clearBlockCipher = liftIO . Low.blockCipherClear . (.mutableBlockCipherCtx)
 
 -- Mutable algorithm
 
@@ -497,7 +497,7 @@ encryptBlockCipherBlocks
     => MutableBlockCipher
     -> ByteString
     -> m BlockCipherText
-encryptBlockCipherBlocks mc pt = liftIO $ Low.blockCipherEncryptBlocks (mutableBlockCipherCtx mc) pt
+encryptBlockCipherBlocks mc pt = liftIO $ Low.blockCipherEncryptBlocks mc.mutableBlockCipherCtx pt
 
 -- NOTE: Not maybe because it should never fail in a proper context (ie, having set the key successfully)
 decryptBlockCipherBlocks
@@ -505,7 +505,7 @@ decryptBlockCipherBlocks
     => MutableBlockCipher
     -> BlockCipherText
     -> m ByteString
-decryptBlockCipherBlocks mc ct = liftIO $ Low.blockCipherDecryptBlocks (mutableBlockCipherCtx mc) ct
+decryptBlockCipherBlocks mc ct = liftIO $ Low.blockCipherDecryptBlocks mc.mutableBlockCipherCtx ct
 
 autoEncryptBlockCipherBlocks
     :: (MonadIO m)

--- a/botan/src/Botan/Cipher.hs
+++ b/botan/src/Botan/Cipher.hs
@@ -240,7 +240,7 @@ ciphers = concat
     [ [ CBC bc pd                               | bc <- blockCiphers, pd <- cbcPaddings ]
     , [ CFB bc (8 * blockCipherBlockSize bc)    | bc <- blockCiphers ]
     , [ XTS bc                                  | bc <- blockCiphers ]
-    , fmap unAEAD aeads
+    , fmap (.unAEAD) aeads
     ]
 
 cbcPaddings :: [ CBCPadding ]
@@ -363,7 +363,7 @@ cipherNonceSizeIsValid n (CFB bc _)         = n == blockCipherBlockSize bc
 cipherNonceSizeIsValid n (XTS bc)           = 1 <= n && n <= blockCipherBlockSize bc -- Always [ 1 .. 16 ]
 cipherNonceSizeIsValid n _haCha20Poly1305   = n `elem` [ 8, 12, 24 ]
 cipherNonceSizeIsValid n (GCM _ _)          = 1 <= n && n <= internalMaximumCipherNonceSize -- True if unbounded
-cipherNonceSizeIsValid n (OCB bc128 _)      = 1 <= n && n <= blockCipherBlockSize (unBlockCipher128 bc128) - 1 -- Always [ 1 .. 15 ]
+cipherNonceSizeIsValid n (OCB bc128 _)      = 1 <= n && n <= blockCipherBlockSize bc128.unBlockCipher128 - 1 -- Always [ 1 .. 15 ]
 cipherNonceSizeIsValid n (EAX _ _)          = 1 <= n && n <= internalMaximumCipherNonceSize -- True if unbounded
 cipherNonceSizeIsValid n (SIV _)            = 1 <= n && n <= internalMaximumCipherNonceSize -- True if unbounded
 cipherNonceSizeIsValid n (CCM _ _ _)        = n == 12
@@ -419,8 +419,8 @@ cipherUpdateGranularity (CBC bc _)          = blockCipherBlockSize bc
 cipherUpdateGranularity (CFB bc _)          = blockCipherBlockSize bc
 cipherUpdateGranularity (XTS bc)            = 2 * blockCipherBlockSize bc
 cipherUpdateGranularity ChaCha20Poly1305    = 1
-cipherUpdateGranularity (GCM bc128 _)       = blockCipherBlockSize (unBlockCipher128 bc128) -- always 16
-cipherUpdateGranularity (OCB bc128 _)       = blockCipherBlockSize (unBlockCipher128 bc128) -- always 16
+cipherUpdateGranularity (GCM bc128 _)       = blockCipherBlockSize bc128.unBlockCipher128 -- always 16
+cipherUpdateGranularity (OCB bc128 _)       = blockCipherBlockSize bc128.unBlockCipher128 -- always 16
 cipherUpdateGranularity (EAX _ _)           = 1
 cipherUpdateGranularity (SIV _)             = 1
 cipherUpdateGranularity (CCM _ _ _)         = 1
@@ -489,7 +489,7 @@ cipherDecryptLazy = undefined
 -- TODO: Wrap in Maybe
 aeadEncrypt :: AEAD -> CipherKey -> CipherNonce -> AEADAssociatedData -> ByteString -> Ciphertext
 aeadEncrypt c k n ad msg = unsafePerformIO $ do
-    ctx <- newCipher (unAEAD c) CipherEncrypt
+    ctx <- newCipher c.unAEAD CipherEncrypt
     setCipherKey ctx k
     setAEADAssociatedData ctx ad
     startCipher ctx n
@@ -498,7 +498,7 @@ aeadEncrypt c k n ad msg = unsafePerformIO $ do
 
 aeadDecrypt ::  AEAD -> CipherKey -> CipherNonce -> AEADAssociatedData -> Ciphertext -> Maybe ByteString
 aeadDecrypt c k n ad ct = unsafePerformIO $ do
-    ctx <- newCipher (unAEAD c) CipherDecrypt
+    ctx <- newCipher c.unAEAD CipherDecrypt
     setCipherKey ctx k
     setAEADAssociatedData ctx ad
     startCipher ctx n
@@ -522,7 +522,7 @@ data MutableCipher = MkMutableCipher
 -- Destructor
 
 destroyCipher :: (MonadIO m) => MutableCipher -> m ()
-destroyCipher = liftIO . Low.cipherDestroy . mutableCipherCtx
+destroyCipher = liftIO . Low.cipherDestroy . (.mutableCipherCtx)
 
 -- Associated types
 
@@ -560,29 +560,29 @@ newCipher c dir = do
 -- Accessors
 
 getCipherName :: (MonadIO m) => MutableCipher -> m ByteString
-getCipherName = liftIO . Low.cipherName . mutableCipherCtx
+getCipherName = liftIO . Low.cipherName . (.mutableCipherCtx)
 
 getCipherKeySpec :: (MonadIO m) => MutableCipher -> m CipherKeySpec
 getCipherKeySpec c = do
-    (mn,mx,md) <- liftIO $ Low.cipherGetKeyspec (mutableCipherCtx c)
+    (mn,mx,md) <- liftIO $ Low.cipherGetKeyspec c.mutableCipherCtx
     return $ keySpec mn mx md
 
 
 getCipherDefaultNonceSize :: (MonadIO m) => MutableCipher -> m Int
-getCipherDefaultNonceSize = liftIO . Low.cipherGetDefaultNonceLength . mutableCipherCtx
+getCipherDefaultNonceSize = liftIO . Low.cipherGetDefaultNonceLength . (.mutableCipherCtx)
 
 getCipherNonceSizeIsValid :: (MonadIO m) => MutableCipher -> Int -> m Bool
-getCipherNonceSizeIsValid c n = liftIO $ Low.cipherValidNonceLength (mutableCipherCtx c) n
+getCipherNonceSizeIsValid c n = liftIO $ Low.cipherValidNonceLength c.mutableCipherCtx n
 
 -- TODO: Rename getAEADTagLength? getAETagLength?
 getCipherTagSize :: (MonadIO m) => MutableCipher -> m Int
-getCipherTagSize = liftIO . Low.cipherGetTagLength . mutableCipherCtx
+getCipherTagSize = liftIO . Low.cipherGetTagLength . (.mutableCipherCtx)
 
 getCipherUpdateGranularity :: (MonadIO m) => MutableCipher -> m Int
-getCipherUpdateGranularity = liftIO . Low.cipherGetUpdateGranularity . mutableCipherCtx
+getCipherUpdateGranularity = liftIO . Low.cipherGetUpdateGranularity . (.mutableCipherCtx)
 
 getCipherIdealUpdateGranularity :: (MonadIO m) => MutableCipher -> m Int
-getCipherIdealUpdateGranularity = liftIO . Low.cipherGetIdealUpdateGranularity . mutableCipherCtx
+getCipherIdealUpdateGranularity = liftIO . Low.cipherGetIdealUpdateGranularity . (.mutableCipherCtx)
 
 -- NOTE: out + ug + tag is safe overestimate for encryption
 -- NOTE: out + ug - tag may not be a safe overestimate for decryption
@@ -591,34 +591,34 @@ getCipherEstimateOutputLength ctx input = do
     o <- getCipherOutputLength ctx input  -- NOTE: Flawed but usable
     u <- getCipherUpdateGranularity ctx -- TODO: When u == 1, it should be just input + t, right?
     t <- getCipherTagSize ctx
-    if mutableCipherDirection ctx == CipherEncrypt
+    if ctx.mutableCipherDirection == CipherEncrypt
         then return (o + u + t)
         else return (o + u - t) -- TODO: Maybe just 'o'...
 
 -- NOTE: Supposed to be an upper bound, may not always be valid? - needs checking
 {-# WARNING getCipherOutputLength "Needs to be confirmed accurate, use getCipherEstimateOutputLength" #-}
 getCipherOutputLength :: (MonadIO m) => MutableCipher -> Int -> m Int
-getCipherOutputLength c n = liftIO $ Low.cipherOutputLength (mutableCipherCtx c) n
+getCipherOutputLength c n = liftIO $ Low.cipherOutputLength c.mutableCipherCtx n
 
 setCipherKey :: (MonadIO m) => MutableCipher -> CipherKey -> m ()
-setCipherKey c key = liftIO $ Low.cipherSetKey (mutableCipherCtx c) key
+setCipherKey c key = liftIO $ Low.cipherSetKey c.mutableCipherCtx key
 
 -- TODO: Consider flipping
 setAEADAssociatedData :: (MonadIO m) => MutableCipher -> ByteString -> m ()
-setAEADAssociatedData c ad = liftIO $ Low.cipherSetAssociatedData (mutableCipherCtx c) ad
+setAEADAssociatedData c ad = liftIO $ Low.cipherSetAssociatedData c.mutableCipherCtx ad
 
 -- Accessory functions
 
 clearCipher :: (MonadIO m) => MutableCipher -> m ()
-clearCipher = liftIO . Low.cipherClear . mutableCipherCtx
+clearCipher = liftIO . Low.cipherClear . (.mutableCipherCtx)
 
 resetCipher :: (MonadIO m) => MutableCipher -> m ()
-resetCipher = liftIO . Low.cipherReset . mutableCipherCtx
+resetCipher = liftIO . Low.cipherReset . (.mutableCipherCtx)
 
 -- Mutable algorithm
 
 startCipher :: (MonadIO m) => MutableCipher -> CipherNonce -> m ()
-startCipher c n = liftIO $ Low.cipherStart (mutableCipherCtx c) n
+startCipher c n = liftIO $ Low.cipherStart c.mutableCipherCtx n
 
 -- NOTE: DOES NOT USE ESTIMATED OUTPUT LENGTH
 updateCipher
@@ -628,7 +628,7 @@ updateCipher
     -> m (Int, ByteString)
 updateCipher c msg = do
     o <- getCipherOutputLength c (ByteString.length msg)
-    liftIO $ Low.cipherUpdate (mutableCipherCtx c) (cipherUpdateFlag CipherUpdate) o msg
+    liftIO $ Low.cipherUpdate c.mutableCipherCtx (cipherUpdateFlag CipherUpdate) o msg
 
 -- updateCipherChunks :: _
 -- updateCipherChunks = undefined
@@ -643,7 +643,7 @@ finalizeCipher
     -> m ByteString
 finalizeCipher c msg = do
     o <- getCipherOutputLength c (ByteString.length msg)
-    (_,out) <- liftIO $ Low.cipherUpdate (mutableCipherCtx c) (cipherUpdateFlag CipherFinal) o msg
+    (_,out) <- liftIO $ Low.cipherUpdate c.mutableCipherCtx (cipherUpdateFlag CipherFinal) o msg
     return out
 
 finalizeResetCipher

--- a/botan/src/Botan/Hash.hs
+++ b/botan/src/Botan/Hash.hs
@@ -484,7 +484,7 @@ destroyHash
     :: (MonadIO m)
     => MutableHash
     -> m ()
-destroyHash = liftIO . Low.hashDestroy . mutableHashCtx
+destroyHash = liftIO . Low.hashDestroy . (.mutableHashCtx)
 
 -- Initializers
 
@@ -502,19 +502,19 @@ getHashName
     :: (MonadIO m)
     => MutableHash
     -> m Low.HashName
-getHashName = liftIO . Low.hashName . mutableHashCtx
+getHashName = liftIO . Low.hashName . (.mutableHashCtx)
 
 getHashBlockSize
     :: (MonadIO m)
     => MutableHash
     -> m Int
-getHashBlockSize = liftIO . Low.hashBlockSize . mutableHashCtx
+getHashBlockSize = liftIO . Low.hashBlockSize . (.mutableHashCtx)
 
 getHashDigestSize
     :: (MonadIO m)
     => MutableHash
     -> m Int
-getHashDigestSize = liftIO . Low.hashOutputLength . mutableHashCtx
+getHashDigestSize = liftIO . Low.hashOutputLength . (.mutableHashCtx)
 
 -- Accessory functions
 
@@ -523,14 +523,14 @@ copyHashState
     => MutableHash
     -> m MutableHash
 copyHashState mh = do
-    ctx <- liftIO $ Low.hashCopyState $ mutableHashCtx mh
-    return $ MkMutableHash (mutableHashType mh) ctx
+    ctx <- liftIO $ Low.hashCopyState mh.mutableHashCtx
+    return $ MkMutableHash mh.mutableHashType ctx
 
 clearHash
     :: (MonadIO m)
     => MutableHash
     -> m ()
-clearHash = liftIO . Low.hashClear . mutableHashCtx
+clearHash = liftIO . Low.hashClear . (.mutableHashCtx)
 
 -- Mutable algorithm
 -- TODO: Flip?
@@ -547,14 +547,14 @@ updateHashChunks
     => MutableHash
     -> [ByteString]
     -> m ()
-updateHashChunks mh chunks = let ctx = mutableHashCtx mh in
-    liftIO $ traverse_ (Low.hashUpdate ctx) chunks
+updateHashChunks mh chunks =
+    liftIO $ traverse_ (Low.hashUpdate mh.mutableHashCtx) chunks
 
 finalizeHash
     :: (MonadIO m)
     => MutableHash
     -> m HashDigest
-finalizeHash = liftIO . Low.hashFinal . mutableHashCtx
+finalizeHash = liftIO . Low.hashFinal . (.mutableHashCtx)
 
 updateFinalizeHash
     :: (MonadIO m)

--- a/botan/src/Botan/Types/Class.hs
+++ b/botan/src/Botan/Types/Class.hs
@@ -265,7 +265,7 @@ newtype GSecretKey = MkGSecretKey { unGSecretKey :: ByteString }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GSecretKey where
-    show = showByteStringHex . unGSecretKey
+    show = showByteStringHex . (.unGSecretKey)
 
 -- NOTE: Cannot do g- / default implementation of new keys since we do not yet
 -- have the secret key constructor.
@@ -303,7 +303,7 @@ newtype GNonce = MkGNonce { unGNonce :: ByteString }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GNonce where
-    show = showByteStringHex . unGNonce
+    show = showByteStringHex . (.unGNonce)
 
 -- HACK: Grodiest bytestring incrementer ever
 instance IsNonce GNonce where
@@ -329,7 +329,7 @@ newtype GSalt = MkGSalt { unGSalt :: ByteString }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GSalt where
-    show = showByteStringHex . unGSalt
+    show = showByteStringHex . (.unGSalt)
 
 --
 -- Password
@@ -344,7 +344,7 @@ newtype GPassword = MkGPassword { unGPassword :: Text }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GPassword where
-    show = Text.unpack . unGPassword
+    show = Text.unpack . (.unGPassword)
 
 --
 -- Digest
@@ -358,7 +358,7 @@ newtype GDigest = MkGDigest { unGDigest :: ByteString }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GDigest where
-    show = showByteStringHex . unGDigest
+    show = showByteStringHex . (.unGDigest)
 
 --
 -- Ciphertext
@@ -372,7 +372,7 @@ newtype GCiphertext = MkGCiphertext { unGCiphertext :: ByteString }
     deriving newtype (Eq, Ord, Encodable)
 
 instance Show GCiphertext where
-    show = showByteStringHex . unGCiphertext
+    show = showByteStringHex . (.unGCiphertext)
 
 --
 -- Incremental Ciphertext
@@ -390,7 +390,7 @@ newtype GLazyCiphertext = MkGLazyCiphertext { unGLazyCiphertext :: Lazy.ByteStri
     deriving newtype (Eq, Ord, Encodable, LazyEncodable)
 
 instance Show GLazyCiphertext where
-    show = showByteStringHex . ByteString.toStrict . unGLazyCiphertext
+    show = showByteStringHex . ByteString.toStrict . (.unGLazyCiphertext)
 
 --
 -- TODO: classes / data families for:


### PR DESCRIPTION
Part of #96 

This commit just enables the language extensions. It does not yet rename fields. That should be done in a separate PR.