### PR TITLE
Fix `base64Decode` against Botan 3.12.0

### DIFF
--- a/botan-low/CHANGELOG.md
+++ b/botan-low/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+* PATCH: fix `base64Decode` failing against `botan` 3.12.0, which now rejects a
+  `NULL` output pointer in `botan_base64_decode`. The size-query call now uses
+  a non-null zero-byte sentinel buffer. See PR
+  [#126](https://github.com/haskell-cryptography/botan/pull/126).
+
 ## 0.2.0.0 -- 2026-03-23
 
 * BREAKING: change more flags from numbers into datatypes. See PR

--- a/botan-low/src/Botan/Low/Utility.hs
+++ b/botan-low/src/Botan/Low/Utility.hs
@@ -24,15 +24,19 @@ module Botan.Low.Utility (
   ) where
 
 import           Botan.Bindings.ConstPtr (ConstPtr (..))
+import           Botan.Bindings.Error
 import           Botan.Bindings.Utility
 import           Botan.Low.Error.Internal
 import           Botan.Low.Internal.ByteString
 import           Botan.Low.Make
 import           Data.ByteString (ByteString)
-import           Data.Text
+import qualified Data.ByteString as BS
+import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import           Data.Word
+import           Foreign.Marshal.Alloc
 import           Foreign.Ptr
+import           Foreign.Storable
 
 -- | Returns 0 if x[0..len] == y[0..len], -1 otherwise.
 constantTimeCompare ::
@@ -109,9 +113,18 @@ base64Decode ::
   -> IO ByteString    -- ^ __out__
 base64Decode txt =
     asBytesLen (Text.encodeUtf8 txt) $ \ base64Ptr base64Len ->
-    allocBytesQueryingCString $ \ bytesPtr szPtr ->
-    botan_base64_decode
-      (ConstPtr base64Ptr)
-      base64Len
-      bytesPtr
-      szPtr
+    alloca $ \ szPtr -> do
+        poke szPtr 0
+        -- Botan 3.12.0 added an any_null_pointers guard on botan_base64_decode that
+        -- rejects a NULL out, so use a non-null zero-byte sentinel for the size-query call.
+        code <- allocaBytes 0 $ \ sentinelPtr ->
+            botan_base64_decode (ConstPtr base64Ptr) base64Len sentinelPtr szPtr
+        case code of
+            BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE -> do
+                sz <- fromIntegral <$> peek szPtr
+                bs <- allocBytes sz $ \ outPtr ->
+                    throwBotanIfNegative_ $ botan_base64_decode
+                      (ConstPtr base64Ptr) base64Len outPtr szPtr
+                actual <- fromIntegral <$> peek szPtr
+                return $! BS.take actual bs
+            _ -> throwBotanError code


### PR DESCRIPTION
## Summary

`Test.Botan.Low.Utility.spec_utility.base64Decode` fails against Botan 3.12.0 with `BOTAN_FFI_ERROR_NULL_POINTER` (-31), thrown from `Botan.Low.Make.throwBotanError`. This PR fixes `base64Decode` so the test passes against 3.12.0 while keeping all other tests green.

## Root cause

Botan 3.12.0 added a top-level null-pointer guard at the entry of `botan_base64_decode` ([`randombit/botan@3368cfcb`](https://github.com/randombit/botan/commit/3368cfcbf680bc0f5935f1803653b03e7cb5bd8c), part of [`randombit/botan#5521`](https://github.com/randombit/botan/pull/5521) "Rollup of small fixes" — commit message: "Add missing nullptr checks to ffi layer"):

```cpp
int botan_base64_decode(const char* base64_str, size_t in_len,
                        uint8_t* out, size_t* out_len) {
   if(any_null_pointers(out, out_len, base64_str)) {       // NEW in 3.12.0
      return BOTAN_FFI_ERROR_NULL_POINTER;
   }
   return ffi_guard_thunk(__func__, [=]() -> int {
      if(*out_len < Botan::base64_decode_max_output(in_len)) {
         *out_len = Botan::base64_decode_max_output(in_len);
         return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;  // size-query branch
      }
      *out_len = Botan::base64_decode(out, std::string(base64_str, in_len));
      return BOTAN_FFI_SUCCESS;
   });
}
```

The new guard rejects `out == nullptr` outright, but `allocBytesQueryingCString` (and `allocBytesQuerying` underneath) follows the FFI's documented two-pass size-query convention — first call with `out = NULL` to learn the required size, then allocate and call again. The lambda body's `INSUFFICIENT_BUFFER_SPACE` branch was specifically designed to support that convention; the new guard makes it unreachable for `out = NULL`. So the first call of the query now returns `NULL_POINTER (-31)` instead of `INSUFFICIENT_BUFFER_SPACE`, and the binding throws.

Three sibling FFI functions (`botan_hex_encode`, `botan_hex_decode`, `botan_base64_encode`) got similarly broad guards in the same upstream PR but their guards still allow `out = NULL` for the size query, so only `base64Decode` regresses.

## Fix

Inline a base64-specific two-pass query in `base64Decode` and pass a non-null zero-byte sentinel buffer (`allocaBytes 0`) for the size-query call:

```haskell
code <- allocaBytes 0 $ \ sentinelPtr ->
    botan_base64_decode (ConstPtr base64Ptr) base64Len sentinelPtr szPtr
```

With `*szPtr = 0`, the callee's own buffer-too-small check (`*out_len < base64_decode_max_output(in_len)`) still fires for any non-empty input and returns `INSUFFICIENT_BUFFER_SPACE` along with the required size, never dereferencing `sentinelPtr`. The two-pass convention is preserved.

The actual decoded length is read from `*szPtr` after the second call and used to trim the returned `ByteString` (`ByteString.take actual bs`). This avoids the existing `allocBytesQueryingCString` helper's "trim at first NUL byte" approach, which is unsound for binary base64 output containing zero bytes (the helper itself notes this with the comment "vulnerable to null byte injection").

## Why scoped to `base64Decode` rather than the shared helper

A one-line equivalent fix in `allocBytesQuerying` (`nullPtr` → non-null sentinel) also makes `base64Decode` pass, but exposes a latent issue in `x509CertGetAuthorityKeyId` and `x509CertGetSubjectKeyId`: with a non-null sentinel they return `SUCCESS` with `*out_len = 0`, which the helper's `case` doesn't handle. Fixing that requires widening shared infrastructure. This PR keeps the change narrow; broader hardening of `allocBytesQuerying` can follow.

## Upstream status

- No issue exists in this repository regarding Botan 3.12.0 (last open Botan version-tracking issue is #122 for Botan 3.11.0).
- No issue exists in `randombit/botan` for the regression itself; `master` still has the over-broad guard.
- Hackage releases of `botan-bindings-0.3.0.0` / `botan-low-0.2.0.0` (2026-03-23) predate Botan 3.12.0 (2026-05-06) and are also affected.

## Verification

Built and tested against `botan` 3.12.0 on `x86_64-linux` / GHC 9.10.3 via `nixpkgs`:

```
0.1.0.0 (botan-low) on Botan 3.12.0:
  Before: 1 of 6296 tests fails (Test.Botan.Low.Utility.base64Decode)
  After:  6296/6296 pass
```
