### PR TITLE
Allow building with GHC 9.14

### DIFF
--- a/botan-bindings/botan-bindings.cabal
+++ b/botan-bindings/botan-bindings.cabal
@@ -112,7 +112,7 @@ library
     Botan.Bindings.X509
     Botan.Bindings.ZFEC
 
-  build-depends: base >=4.16 && <4.22
+  build-depends: base >=4.16 && <4.23
   includes: botan/ffi.h
 
   if flag(pkg-config)

--- a/botan-low/botan-low.cabal
+++ b/botan-low/botan-low.cabal
@@ -148,7 +148,7 @@ test-suite test
     containers,
     hspec,
     tasty,
-    tasty-hspec,
+    tasty-hspec >=1.2,
     tasty-hunit,
     tasty-quickcheck,
     text,

--- a/botan-low/botan-low.cabal
+++ b/botan-low/botan-low.cabal
@@ -127,7 +127,7 @@ library
     Botan.Low.Remake
 
   build-depends:
-    base >=4.16 && <4.22,
+    base >=4.16 && <4.23,
     botan-bindings ^>=0.3,
     bytestring >=0.11 && <0.13,
     deepseq >=1.1 && <2,

--- a/botan/botan.cabal
+++ b/botan/botan.cabal
@@ -155,7 +155,7 @@ library
     Botan.Prelude
 
   build-depends:
-    base >=4.16 && <4.22,
+    base >=4.16 && <4.23,
     botan-low ^>=0.2,
     bytestring >=0.11 && <0.13,
     deepseq >=1.1 && <2,


### PR DESCRIPTION
Partially address #116 

Changes
* relaxes `base` bounds to allow `base-4.22` 
* tightens the `tasty-hspec` lower bound to `>=1.2`, because the test suite uses APIs such as `testSpec` and `TreatPendingAsSuccess`

Locally tests passes with:
```sh
cabal test all -w ghc-9.14 --test-show-details=direct \
  --allow-newer=tasty-hspec:base
  ```
  
Full support for GHC 9.14 is blocked by https://github.com/mitchellwrosen/tasty-hspec/pull/38

