### PR TITLE
Fix script names in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,9 @@ To perform a pre-commit code formatting pass, run all the following:
 
 ```console
 ./scripts/format-cabal-gild.sh
-./scripts/format-fix-whitespace.sh
-./scripts/format-stylish-haskell
-./scripts/lint-cabal
-./scripts/test-cabal-docspec
+./scripts/format-stylish-haskell.sh
+./scripts/lint-cabal.sh
+./scripts/test-cabal-docspec.sh
 ```
 
 ## Pull requests


### PR DESCRIPTION
Updates `CONTRIBUTING.md` to use the actual names from [scripts](https://github.com/haskell-cryptography/botan/tree/main/scripts):
* `./scripts/format-fix-whitespace.sh` [was removed](https://github.com/haskell-cryptography/botan/commit/5d19e07d352bfb0376e94926e76a9e7b85d139ea)
* some commands were missing the `.sh` extension