### PR TITLE
`PubKey.KeyAgreement` docspec and example

### DIFF
--- a/botan-low/botan-low.cabal
+++ b/botan-low/botan-low.cabal
@@ -174,6 +174,7 @@ test-suite test
     Test.Botan.Low.PubKey.ElGamal
     Test.Botan.Low.PubKey.Encrypt
     Test.Botan.Low.PubKey.KeyAgreement
+    Test.Botan.Low.PubKey.KeyAgreement.Example
     Test.Botan.Low.PubKey.KeyEncapsulation
     Test.Botan.Low.PubKey.RSA
     Test.Botan.Low.PubKey.SM2

--- a/botan-low/src/Botan/Low/PubKey/KeyAgreement.hs
+++ b/botan-low/src/Botan/Low/PubKey/KeyAgreement.hs
@@ -76,40 +76,72 @@ on the shared secret to produce an output of the desired length.
 
 {- $usage
 
+This is a simplified, executable example showing how Alice and Bob can derive the
+same shared secret using key agreement.
+-}
+
+{-
+
+>>> :{
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+import Botan.Low.PubKey
+import Botan.Low.PubKey.KeyAgreement
+import Botan.Low.RNG
+import Botan.Low.Hash
+import Botan.Low.KDF
+import Data.ByteString (ByteString)
+:}
+
 First, Alice and Bob generate their private keys:
 
-> import Botan.Low.PubKey
-> import Botan.Low.PubKey.KeyAgreement
-> import Botan.Low.RNG
-> import Botan.Low.Hash
-> import Botan.Low.KDF
-> rng <- rngInit "system"
-> -- Alice creates her private key
-> alicePrivKey <- privKeyCreate ECDH Secp521r1 rng
-> -- Bob creates his private key
-> bobPrivKey <-  privKeyCreate ECDH Secp521r1 rng
+>>> :{
+generateKeys :: IO (PrivKey, PrivKey)
+generateKeys = do
+  rng <- rngInit UserRNG
+  alicePrivKey <- privKeyCreate ECDH Secp521r1 rng
+  bobPrivKey   <- privKeyCreate ECDH Secp521r1 rng
+  pure (alicePrivKey, bobPrivKey)
+:}
 
-Then, they exchange their public keys using any channel, private or public:
+Then, they exchange their public keys using any channel, private or public
+and independently derive shared keys.
 
-> -- Alice and Bob exchange public keys
-> alicePubKey <- keyAgreementExportPublic alicePrivKey
-> bobPubKey <- keyAgreementExportPublic bobPrivKey
-> -- ...
+Alice and Bob exchange public keys:
 
-Then, they may separately generate the same agreed-upon key and a randomized,
-agreed-upon salt:
+>>> :{
+deriveSharedKeys :: PrivKey -> PrivKey -> IO (ByteString, ByteString)
+deriveSharedKeys alicePrivKey bobPrivKey = do
+  rng <- rngInit UserRNG
+  alicePubKey <- keyAgreementExportPublic alicePrivKey
+  bobPubKey <- keyAgreementExportPublic bobPrivKey
+  salt <- rngGet rng 4
 
-> salt <- rngGet rng 4
-> -- Alice generates her shared key:
-> aliceKeyAgreement <- keyAgreementCreate alicePrivKey (kdf2 SHA256)
-> aliceSharedKey    <- keyAgreement aliceKeyAgreement bobPubKey salt
-> -- Bob generates his shared key:
-> bobKeyAgreement   <- keyAgreementCreate bobPrivKey (kdf2 SHA256)
-> bobSharedKey      <- keyAgreement bobKeyAgreement alicePubKey salt
-> -- They are the same
-> aliceSharedKey == bobSharedKey
-> -- True
+  aliceKeyAgreement <- keyAgreementCreate alicePrivKey (kdf2 SHA256)
+  aliceSharedKey <- keyAgreement aliceKeyAgreement bobPubKey salt
 
+  bobKeyAgreement <- keyAgreementCreate bobPrivKey (kdf2 SHA256)
+  bobSharedKey <- keyAgreement bobKeyAgreement alicePubKey salt
+
+  pure (aliceSharedKey, bobSharedKey)
+:}
+
+Now we can check that both parties derive the same shared key using the same salt:
+
+>>> :{
+main :: IO ()
+main = do
+  (alicePrivKey, bobPrivKey) <- generateKeys
+  (aliceSharedKey, bobSharedKey) <- deriveSharedKeys alicePrivKey bobPrivKey
+  print (aliceSharedKey == bobSharedKey)
+:}
+
+>>> main
+True
+
+-}
+
+{-
 > WARNING: There used to be a memory leak in keyAgreement. Please
 > report this bug to the maintainers if it returns.
 

--- a/botan-low/test/Main.hs
+++ b/botan-low/test/Main.hs
@@ -20,6 +20,7 @@ import qualified Test.Botan.Low.PubKey.Ed25519
 import qualified Test.Botan.Low.PubKey.ElGamal
 import qualified Test.Botan.Low.PubKey.Encrypt
 import qualified Test.Botan.Low.PubKey.KeyAgreement
+import qualified Test.Botan.Low.PubKey.KeyAgreement.Example
 import qualified Test.Botan.Low.PubKey.KeyEncapsulation
 import qualified Test.Botan.Low.PubKey.RSA
 import qualified Test.Botan.Low.PubKey.Sign
@@ -97,6 +98,9 @@ tests = do
       , pubKeyElGamalTests
       , pubKeyEncryptTests
       , pubKeyKeyAgreementTests
+      , testGroup "Test.Botan.Low.PubKey.KeyAgreement.Example"
+          [ testCase "example" Test.Botan.Low.PubKey.KeyAgreement.Example.main
+          ]
       , pubKeyKeyEncapsulationTests
       , pubKeyRsaTests
       , pubKeySignTests

--- a/botan-low/test/Test/Botan/Low/PubKey/KeyAgreement/Example.hs
+++ b/botan-low/test/Test/Botan/Low/PubKey/KeyAgreement/Example.hs
@@ -1,0 +1,44 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | The executable example described in the Haddock documentation of the
+-- "Botan.Low.PubKey.KeyAgreement" module.
+--
+-- NOTE: when changing this example, also change the Haddock documentation in
+-- the "Botan.Low.PubKey.KeyAgreement" module.
+module Test.Botan.Low.PubKey.KeyAgreement.Example (main) where
+
+import           Botan.Low.Hash
+import           Botan.Low.KDF
+import           Botan.Low.PubKey
+import           Botan.Low.PubKey.KeyAgreement
+import           Botan.Low.RNG
+import           Data.ByteString (ByteString)
+
+generateKeys :: IO (PrivKey, PrivKey)
+generateKeys = do
+  rng <- rngInit UserRNG
+  alicePrivKey <- privKeyCreate ECDH Secp521r1 rng
+  bobPrivKey <- privKeyCreate ECDH Secp521r1 rng
+  pure (alicePrivKey, bobPrivKey)
+
+deriveSharedKeys :: PrivKey -> PrivKey -> IO (ByteString, ByteString)
+deriveSharedKeys alicePrivKey bobPrivKey = do
+  rng <- rngInit UserRNG
+  alicePubKey <- keyAgreementExportPublic alicePrivKey
+  bobPubKey <- keyAgreementExportPublic bobPrivKey
+  salt <- rngGet rng 4
+
+  aliceKeyAgreement <- keyAgreementCreate alicePrivKey (kdf2 SHA256)
+  aliceSharedKey <- keyAgreement aliceKeyAgreement bobPubKey salt
+
+  bobKeyAgreement <- keyAgreementCreate bobPrivKey (kdf2 SHA256)
+  bobSharedKey <- keyAgreement bobKeyAgreement alicePubKey salt
+
+  pure (aliceSharedKey, bobSharedKey)
+
+main :: IO ()
+main = do
+  (alicePrivKey, bobPrivKey) <- generateKeys
+  (aliceSharedKey, bobSharedKey) <- deriveSharedKeys alicePrivKey bobPrivKey
+  print (aliceSharedKey == bobSharedKey)


### PR DESCRIPTION
Converts the `Botan.Low.PubKey.KeyAgreement` comment into `docspec` and exectable example.

Address  #112.

Validated with:
```sh
./scripts/test-cabal-docspec.sh
cabal test botan-low
```
result:
```text
[   1.29529] docspec.phase1: Botan.Low.PubKey.KeyAgreement: ~/botan/botan-low/src/Botan/Low/PubKey/KeyAgreement.hs
...
[   2.36582] doctest.summary: 
Total:        66; Tried:   66; Skipped:    0; Success:   66; Errors:    0; Failures    0
Examples:     63; Tried:   63; Skipped:    0; Success:   63; Errors:    0; Failures    0
Setup:         3; Tried:    3; Skipped:    0; Success:    3; Errors:    0; Failures    0

[   2.36842] peu.completed: OK
```