### PR TITLE
Add missing FFI error exceptions

### DIFF
--- a/botan-bindings/src/Botan/Bindings/Error.hsc
+++ b/botan-bindings/src/Botan/Bindings/Error.hsc
@@ -39,6 +39,7 @@ module Botan.Bindings.Error (
   , pattern BOTAN_FFI_ERROR_TLS_ERROR
   , pattern BOTAN_FFI_ERROR_HTTP_ERROR
   , pattern BOTAN_FFI_ERROR_ROUGHTIME_ERROR
+  , pattern BOTAN_FFI_ERROR_TPM_ERROR
   , pattern BOTAN_FFI_ERROR_UNKNOWN_ERROR
   , botan_error_description
   , botan_error_last_exception_message
@@ -73,6 +74,7 @@ pattern BOTAN_FFI_SUCCESS
     ,   BOTAN_FFI_ERROR_TLS_ERROR
     ,   BOTAN_FFI_ERROR_HTTP_ERROR
     ,   BOTAN_FFI_ERROR_ROUGHTIME_ERROR
+    ,   BOTAN_FFI_ERROR_TPM_ERROR
     ,   BOTAN_FFI_ERROR_UNKNOWN_ERROR
     ::  (Eq a, Num a) => a
 
@@ -139,10 +141,11 @@ pattern BOTAN_FFI_ERROR_HTTP_ERROR = #const BOTAN_FFI_ERROR_HTTP_ERROR
 -- | Note: this code is undocumented in @botan/ffi.h@.
 pattern BOTAN_FFI_ERROR_ROUGHTIME_ERROR = #const BOTAN_FFI_ERROR_ROUGHTIME_ERROR
 
+-- | An error occurred when performing TPM2 interactions.
+pattern BOTAN_FFI_ERROR_TPM_ERROR = #const BOTAN_FFI_ERROR_TPM_ERROR
+
 -- | Something bad happened, but we are not sure why or how.
 pattern BOTAN_FFI_ERROR_UNKNOWN_ERROR = #const BOTAN_FFI_ERROR_UNKNOWN_ERROR
-
--- TODO: add a binding for BOTAN_FFI_TEMP_ERROR. See issue #44.
 
 foreign import capi safe "botan/ffi.h botan_error_description"
     botan_error_description

--- a/botan-low/src/Botan/Low/Error.hs
+++ b/botan-low/src/Botan/Low/Error.hs
@@ -40,6 +40,10 @@ module Botan.Low.Error (
   , Internal.InvalidObjectStateException(..)
   , Internal.NotImplementedException(..)
   , Internal.InvalidObjectException(..)
+  , Internal.TLSErrorException(..)
+  , Internal.HTTPErrorException(..)
+  , Internal.RoughtimeErrorException(..)
+  , Internal.TPMErrorException(..)
   , Internal.UnknownException(..)
   ) where
 

--- a/botan-low/src/Botan/Low/Error/Internal.hs
+++ b/botan-low/src/Botan/Low/Error/Internal.hs
@@ -39,6 +39,10 @@ module Botan.Low.Error.Internal (
   , NotImplementedException(..)
   , InvalidObjectException(..)
   , UnknownException(..)
+  , TLSErrorException(..)
+  , HTTPErrorException(..)
+  , RoughtimeErrorException(..)
+  , TPMErrorException(..)
     -- ** Throwing and catching
   , throwBotanError
   , throwBotanIfNegative
@@ -203,6 +207,26 @@ data InvalidObjectException
     deriving stock (Show)
     deriving Exception via ViaSomeBotanException InvalidObjectException
 
+data TLSErrorException
+    = TLSErrorException BotanErrorCode BotanErrorMessage CallStack
+    deriving stock Show
+    deriving Exception via ViaSomeBotanException TLSErrorException
+
+data HTTPErrorException
+    = HTTPErrorException BotanErrorCode BotanErrorMessage CallStack
+    deriving stock Show
+    deriving Exception via ViaSomeBotanException HTTPErrorException
+
+data RoughtimeErrorException
+    = RoughtimeErrorException BotanErrorCode BotanErrorMessage CallStack
+    deriving stock Show
+    deriving Exception via ViaSomeBotanException RoughtimeErrorException
+
+data TPMErrorException
+    = TPMErrorException BotanErrorCode BotanErrorMessage CallStack
+    deriving stock Show
+    deriving Exception via ViaSomeBotanException TPMErrorException
+
 data UnknownException
     = UnknownException BotanErrorCode BotanErrorMessage CallStack
     deriving stock (Show)
@@ -277,6 +301,11 @@ throwBotanErrorWithCallstack e cs =  do
         BOTAN_FFI_ERROR_INVALID_OBJECT_STATE        -> throwIO $ InvalidObjectStateException bec emsg cs
         BOTAN_FFI_ERROR_NOT_IMPLEMENTED             -> throwIO $ NotImplementedException bec emsg cs
         BOTAN_FFI_ERROR_INVALID_OBJECT              -> throwIO $ InvalidObjectException bec emsg cs
+        BOTAN_FFI_ERROR_INVALID_OBJECT              -> throwIO $ InvalidObjectException bec emsg cs
+        BOTAN_FFI_ERROR_TLS_ERROR                   -> throwIO $ TLSErrorException bec emsg cs
+        BOTAN_FFI_ERROR_HTTP_ERROR                  -> throwIO $ HTTPErrorException bec emsg cs
+        BOTAN_FFI_ERROR_ROUGHTIME_ERROR             -> throwIO $ RoughtimeErrorException bec emsg cs
+        BOTAN_FFI_ERROR_TPM_ERROR                   -> throwIO $ TPMErrorException bec emsg cs
         _                                           -> throwIO $ UnknownException bec emsg cs
   where
     bec = BotanErrorCode e


### PR DESCRIPTION
Fixes #44
Address #45

Adds missing higher-level exceptions for Botan FFI return codes in `botan-low`.

Adds the missing binding for `BOTAN_FFI_ERROR_TPM_ERROR`.